### PR TITLE
Use g:wiki_journal_format to create new journal pages

### DIFF
--- a/autoload/wiki/journal.vim
+++ b/autoload/wiki/journal.vim
@@ -6,7 +6,9 @@
 "
 
 function! wiki#journal#make_note(...) abort " {{{1
-  let l:date = (a:0 > 0 ? a:1 : strftime('%Y-%m-%d'))
+  let l:date = a:0 > 0
+      \ ? a:1
+      \ : strftime(get(g:, 'wiki_journal_format', '%Y-%m-%d'))
   call wiki#url#parse('journal:' . l:date).open()
 endfunction
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -117,6 +117,11 @@ CONFIGURATION                                                     *wiki-config*
 
   Default: `'journal'`
 
+*g:wiki_journal_format*
+  The format string used to construct new journal files.
+
+  Default: `'%Y-%m-%d'`
+
 *g:wiki_projects*
   List of project names (or regexes) used to collect journal entries when
   creating weekly or monthly summaries.


### PR DESCRIPTION
I'm trying to address the (very small) number of issues that mean I currently maintain my own fork of this plugin. At the moment those are:

* Weekly journals
* 'Summary' as a title instead of 'Innhand'
* ~.wiki filetype detection does not always work (although I haven't tested this more recently)~ I tested this again and it works

I'm unsure of the approach here so please feel free to point me in a better direction if you'd prefer this solved in a different way.

Fixes #2 