### PR TITLE
Config to pick default link type

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -242,8 +242,14 @@ function! wiki#link#template_md(url, ...) abort " {{{1
   return '[' . l:text . '](' . a:url . ')'
 endfunction
 
+" }}}1
 function! wiki#link#pick_template_type(url, ...) abort
-  if !empty(g:wiki_link_target_type) && exists('*wiki#link#template_' . g:wiki_link_target_type)
+  "
+  " Pick the relevant link template command to use based on the users
+  " settings. Default to the wiki style one if its not set.
+  "
+  if !empty(g:wiki_link_target_type) &&
+    \ exists('*wiki#link#template_' . g:wiki_link_target_type)
     return call('wiki#link#template_' . g:wiki_link_target_type, [a:url] + a:000)
   else
     return wiki#link#template_wiki(a:url, a:000)

--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -242,6 +242,14 @@ function! wiki#link#template_md(url, ...) abort " {{{1
   return '[' . l:text . '](' . a:url . ')'
 endfunction
 
+function! wiki#link#pick_template_type(url, ...) abort
+  if !empty(g:wiki_link_target_type) && exists('*wiki#link#template_' . g:wiki_link_target_type)
+    return call('wiki#link#template_' . g:wiki_link_target_type, [a:url] + a:000)
+  else
+    return wiki#link#template_wiki(a:url, a:000)
+  endif
+endfunction
+
 " }}}1
 function! wiki#link#template_word(url, ...) abort " {{{1
   "
@@ -266,14 +274,14 @@ function! wiki#link#template_word(url, ...) abort " {{{1
   " First try local page
   "
   if filereadable(printf('%s/%s.%s', expand('%:p:h'), l:url, b:wiki.extension))
-    return wiki#link#template_wiki(l:url, l:text)
+    return wiki#link#pick_template_type(l:url, l:text)
   endif
 
   "
   " Next try at wiki root
   "
   if filereadable(printf('%s/%s.%s', b:wiki.root, l:url, b:wiki.extension))
-    return wiki#link#template_wiki('/' . l:url, l:text)
+    return wiki#link#pick_template_type('/' . l:url, l:text)
   endif
 
   "
@@ -287,9 +295,9 @@ function! wiki#link#template_word(url, ...) abort " {{{1
   " Solve trivial cases first
   "
   if len(l:candidates) == 0
-    return wiki#link#template_wiki((b:wiki.in_journal ? '/' : '') . l:url, l:text)
+    return wiki#link#pick_template_type((b:wiki.in_journal ? '/' : '') . l:url, l:text)
   elseif len(l:candidates) == 1
-    return wiki#link#template_wiki('/' . l:candidates[0], l:url, l:text)
+    return wiki#link#pick_template_type('/' . l:candidates[0], l:url, l:text)
   endif
 
   "
@@ -310,13 +318,13 @@ function! wiki#link#template_word(url, ...) abort " {{{1
     if empty(l:choice) | return l:url | endif
 
     if l:choice ==# 'n'
-      return wiki#link#template_wiki('/' . l:url, l:text)
+      return wiki#link#pick_template_type('/' . l:url, l:text)
     endif
 
     try
       let l:cand = l:candidates[l:choice - 1]
       redraw!
-      return wiki#link#template_wiki('/' . l:cand, l:url)
+      return wiki#link#pick_template_type('/' . l:cand, l:url)
     catch
       continue
     endtry
@@ -325,7 +333,7 @@ endfunction
 
 " }}}1
 function! wiki#link#template_ref(...) abort " {{{1
-  return call('wiki#link#template_wiki', a:000)
+  return call('wiki#link#pick_template_type', a:000)
 endfunction
 
 " }}}1

--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -252,7 +252,7 @@ function! wiki#link#pick_template_type(url, ...) abort
     \ exists('*wiki#link#template_' . g:wiki_link_target_type)
     return call('wiki#link#template_' . g:wiki_link_target_type, [a:url] + a:000)
   else
-    return wiki#link#template_wiki(a:url, a:000)
+    return call ('wiki#link#template_wiki', [a:url] + a:000)
   endif
 endfunction
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -163,6 +163,15 @@ CONFIGURATION                                                     *wiki-config*
 
   Default: ''
 
+*g:wiki_link_target_type*
+  This option may be used to pick the default style of link that will be used. An
+  example:
+
+  Setting this to `md` will cause Markdown style links to be added by default,
+  rather than `wiki` style links.
+
+  Default: 'wiki'
+
 *g:wiki_journal*
   A dictionary for configuring the journal/diary feature. Available options
   are:

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -164,11 +164,11 @@ CONFIGURATION                                                     *wiki-config*
   Default: ''
 
 *g:wiki_link_target_type*
-  This option may be used to pick the default style of link that will be used. An
-  example:
+  This option may be used to pick the default style of link that will be used.
 
   Setting this to `md` will cause Markdown style links to be added by default,
-  rather than `wiki` style links.
+  rather than `wiki` style links. Toggling between link types can still be
+  achieved using |WikiLinkToggle|.
 
   Default: 'wiki'
 

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -36,7 +36,7 @@ call wiki#init#option('wiki_index_name', 'index')
 call wiki#init#option('wiki_root', '')
 call wiki#init#option('wiki_link_extension', '')
 call wiki#init#option('wiki_link_target_map', '')
-call wiki#init#option('wiki_link_target_type', '')
+call wiki#init#option('wiki_link_target_type', 'wiki')
 call wiki#init#option('wiki_month_names', [
       \ 'January', 'February', 'March', 'April', 'May', 'June', 'July',
       \ 'August', 'September', 'October', 'November', 'December'

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -36,6 +36,7 @@ call wiki#init#option('wiki_index_name', 'index')
 call wiki#init#option('wiki_root', '')
 call wiki#init#option('wiki_link_extension', '')
 call wiki#init#option('wiki_link_target_map', '')
+call wiki#init#option('wiki_link_target_type', '')
 call wiki#init#option('wiki_month_names', [
       \ 'January', 'February', 'March', 'April', 'May', 'June', 'July',
       \ 'August', 'September', 'October', 'November', 'December'

--- a/test/test_links.vim
+++ b/test/test_links.vim
@@ -8,7 +8,7 @@ endfunction
 
 runtime plugin/wiki.vim
 
-" Test toggle normal on regular markdown links
+" Test toggle normal on regular markdown links using wiki style links
 try
   bwipeout!
   silent edit ex1-basic/index.wiki
@@ -20,6 +20,7 @@ try
   endif
 endtry
 
+" Test toggle normal on regular markdown links using md style links
 let g:wiki_link_target_type = 'md'
 
 try
@@ -30,6 +31,22 @@ try
 
   if getline('.') !=# '[This is a wiki](this-is-a-wiki).'
     call wiki#test#error(expand('<sfile>'), 'Should have created a parsed markdown link.')
+  endif
+endtry
+
+" Test toggle normal on regular markdown links using md style links with the
+" markdown extension
+let g:wiki_link_target_type = 'md'
+let g:wiki_link_extension = '.md'
+
+try
+  bwipeout!
+  silent edit ex1-basic/index.wiki
+  normal! 3G
+  silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
+
+  if getline('.') !=# '[This is a wiki](this-is-a-wiki.md).'
+    call wiki#test#error(expand('<sfile>'), 'Should have created a markdown link with extension.')
   endif
 endtry
 

--- a/test/test_links.vim
+++ b/test/test_links.vim
@@ -16,7 +16,20 @@ try
   silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
 
   if getline('.') !=# '[[this-is-a-wiki|This is a wiki]].'
-    call wiki#test#error(expand('<sfile>'), 'Should have created a parsed link.')
+    call wiki#test#error(expand('<sfile>'), 'Should have created a parsed wiki link.')
+  endif
+endtry
+
+let g:wiki_link_target_type = 'md'
+
+try
+  bwipeout!
+  silent edit ex1-basic/index.wiki
+  normal! 3G
+  silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
+
+  if getline('.') !=# '[This is a wiki](this-is-a-wiki).'
+    call wiki#test#error(expand('<sfile>'), 'Should have created a parsed markdown link.')
   endif
 endtry
 


### PR DESCRIPTION
Hey!

Vimscript isn't my strongest language, so shout up if something is done wrong/inefficiently/ugly.

This just adds a config option to pick the default link style, which is currently just `wiki` or `md`.

TODO:

 - [x] : Get feedback on a good config option name.
 - [x] : Write docs (pending getting a name okay-ed)
 - [x] : Write a test?

I'll admit to not really knowing the workflow for tests in vimscript, so for now I've just done some manual ones.

One weird thing I saw was that on line 306 of `link.vim`, 3 arguments seem to be passed over, when I can only see the first and second being used?

