### PR TITLE
Silently cancel completion if not link is found

### DIFF
--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -9,7 +9,7 @@ function! wiki#complete#omnicomplete(findstart, base) " {{{1
   if a:findstart
     let l:line = getline('.')[:col('.')-2]
     let l:cnum = match(l:line, '\[\[\zs[^\\[\]]\{-}$')
-    if l:cnum < 0 | return -1 | endif
+    if l:cnum < 0 | return -3 | endif
 
     let l:base = l:line[l:cnum:]
 


### PR DESCRIPTION
Before this commit completion func returned `-1` which means "cancel
completion with an error" vim and does nothing in neovim. This commit
makes it return `-3` which cancels the completion silently. That
unbreaks neovim which doesn't handle `-1` and proceeds with completion
fails on undefined `s:ctx` variable instead.