### PR TITLE
md link template text: fall back to url if empty

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -240,6 +240,9 @@ function! wiki#link#template_md(url, ...) abort " {{{1
   let l:text = a:0 > 0 ? a:1 : ''
   if empty(l:text)
     let l:text = input('Link text: ')
+    if empty(l:text)
+      let l:text = a:url
+    endif
   endif
   return '[' . l:text . '](' . a:url . ')'
 endfunction


### PR DESCRIPTION
This resolves one nit I had when I started using wiki.vim:
The interactive title prompt on link toggle defaults to empty.

For me, probably others, 98% or so of the time I just want to use the link target
as the title, like vimwiki does.

This looks like what's expected in https://github.com/lervag/wiki.vim/blob/master/test/test_markdown.vim#L27 but I guess that's the old vimwiki code path.

Another idea would be to add a setting var to disable the prompt, but I'd always rather fix the default than add another esoteric setting that increases the spread of user configs etc.

ps idk how to run tests #38