### PR TITLE
make tests set runtimepath relative to sfile so it works without vundle

### DIFF
--- a/test/init.vim
+++ b/test/init.vim
@@ -1,5 +1,5 @@
 set nocompatible
-let &runtimepath = '~/.vim/bundle/wiki.vim,' . &runtimepath
+let &runtimepath = expand('<sfile>:p:h:h') . ',' . &runtimepath
 filetype plugin indent on
 syntax enable
 


### PR DESCRIPTION
lifted from https://github.com/junegunn/vader.vim/blob/master/test/vimrc