### PR TITLE
Update wiki.txt

### DIFF
--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -98,7 +98,8 @@ FEATURES                                                  *wiki-intro-features*
     - `iu au` Link url
     - `it at` Link text
 - Support for journal entries
-  - Navigating the journal back and forth with `<c-j>` and `<c-k>`
+  - Navigating the journal back and forth with `<Plug>(wiki-journal-next)`
+    and `<Plug>(wiki-journal-prev)`.
   - Support for parsing journal entries in order to make weekly and monthly
     summaries. The parsed result needs manual editing for good results.
 - Utility functionality


### PR DESCRIPTION
The `<c-j>` and `<c-k>` bindings doesn't seem to have been set. And as such doesn't appear in the list under "DEFAULT MAPPINGS". I've changed the description to include the wiki-commands instead.