### PR TITLE
Fix bug introduced in d9004ae

### DIFF
--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -9,7 +9,7 @@ function! wiki#page#open(page) abort "{{{1
   let l:page =
         \ !empty(g:wiki_link_target_map) && exists('*' . g:wiki_link_target_map)
         \ ? call(g:wiki_link_target_map, [a:page])
-        \ : ''
+        \ : a:page
   call wiki#url#parse('wiki:/' . l:page).open()
 endfunction
 


### PR DESCRIPTION
d9004ae makes `WikiOpen` fail to open or create a page if no `wiki_link_target_map` is set.