### PR TITLE
Add option for function to transform paths of new pages

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -316,8 +316,8 @@ function! wiki#link#template_word(url, ...) abort " {{{1
   "
   " Allow to map text -> url
   "
-  if !empty(g:wiki_link_target_map) && exists('*' . g:wiki_link_target_map)
-    let l:url = call(g:wiki_link_target_map, [a:url])
+  if !empty(g:wiki_map_link_target) && exists('*' . g:wiki_map_link_target)
+    let l:url = call(g:wiki_map_link_target, [a:url])
     if empty(l:text) && l:url !=# a:url
       let l:text = a:url
     endif

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -7,8 +7,8 @@
 
 function! wiki#page#open(page) abort "{{{1
   let l:page =
-        \ !empty(g:wiki_page_create_map) && exists('*' . g:wiki_page_create_map)
-        \ ? call(g:wiki_page_create_map, [a:page])
+        \ !empty(g:wiki_map_create_page) && exists('*' . g:wiki_map_create_page)
+        \ ? call(g:wiki_map_create_page, [a:page])
         \ : a:page
   call wiki#url#parse('wiki:/' . l:page).open()
 endfunction

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -7,8 +7,8 @@
 
 function! wiki#page#open(page) abort "{{{1
   let l:page =
-        \ !empty(g:wiki_link_target_map) && exists('*' . g:wiki_link_target_map)
-        \ ? call(g:wiki_link_target_map, [a:page])
+        \ !empty(g:wiki_page_create_map) && exists('*' . g:wiki_page_create_map)
+        \ ? call(g:wiki_page_create_map, [a:page])
         \ : a:page
   call wiki#url#parse('wiki:/' . l:page).open()
 endfunction

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -9,7 +9,7 @@ function! wiki#page#open(page) abort "{{{1
   let l:page =
         \ !empty(g:wiki_link_target_map) && exists('*' . g:wiki_link_target_map)
         \ ? call(g:wiki_link_target_map, [a:page])
-        \ : ''
+        \ : a:page
   call wiki#url#parse('wiki:/' . l:page).open()
 endfunction
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -159,11 +159,11 @@ CONFIGURATION                                                     *wiki-config*
 
   Default: ''
 
-*g:wiki_link_target_map*
+*g:wiki_map_link_target*
   This option may be used to transform text before creating a new link. An
   example: >
 
-    let g:wiki_link_target_map = 'MyFunction'
+    let g:wiki_map_link_target = 'MyFunction'
 
     function MyFunction(text) abort
       return substitute(tolower(a:text), '\s\+', '-', 'g')
@@ -344,11 +344,11 @@ CONFIGURATION                                                     *wiki-config*
 
   Default: `'~/.local/zotero'`
 
-*g:wiki_page_create_map*
+*g:wiki_map_create_page*
   This option may be used to transform text before creating a new page. An
   example: >
 
-    let g:wiki_page_create_map = 'MyFunction'
+    let g:wiki_map_create_page = 'MyFunction'
 
     function MyFunction(url) abort
       let l:url = g:wiki_root . '/' . a:url
@@ -386,7 +386,7 @@ possible.
 *WikiOpen*
   Open (or create) a page. Asks for user input to specify the page name. When
   not already inside a wiki, the wiki root is given by |g:wiki_root|. If
-  |g:wiki_page_create_map| is specified, it will be used to transform the
+  |g:wiki_map_create_page| is specified, it will be used to transform the
   input before opening/creating the page.
 
 *<plug>(wiki-journal)*
@@ -423,7 +423,7 @@ possible.
 *<plug>(wiki-link-open)*
 *WikiLinkOpen*
   Open/follow link. Will create a new link if the text under the cursor is not
-  already a link. If |g:wiki_link_target_map| is specified, it will be used to
+  already a link. If |g:wiki_map_link_target| is specified, it will be used to
   transform the link when creating it.
 
                                                          *#User#WikiLinkOpened*
@@ -449,7 +449,7 @@ possible.
 *<plug>(wiki-link-toggle-visual)*    |xmap|
 *<plug>(wiki-link-toggle-operator)*  |map-operator|
 *WikiLinkToggle*
-  Toggle wiki link. If |g:wiki_link_target_map| is specified, it will be used
+  Toggle wiki link. If |g:wiki_map_link_target| is specified, it will be used
   to transform the link when creating it.
 
 *<plug>(wiki-list-toggle)*

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -171,7 +171,6 @@ CONFIGURATION                                                     *wiki-config*
 <
   With the above setting, links created with |WikiLinkOpen| or
   |WikiLinkToggle| (or related mappings) will be transformed by `MyFunction`.
-  The filename for pages created with |WikiOpen| will also be transformed.
   As an example, if one creates a link from the text "Some text", the link
   becomes "[[some-text|Some text]]".
 
@@ -345,6 +344,28 @@ CONFIGURATION                                                     *wiki-config*
 
   Default: `'~/.local/zotero'`
 
+*g:wiki_page_create_map*
+  This option may be used to transform text before creating a new page. An
+  example: >
+
+    let g:wiki_page_create_map = 'MyFunction'
+
+    function MyFunction(url) abort
+      let l:url = g:wiki_root . '/' . a:url
+      " Test if the file exists
+      if empty(glob(expand(l:url)))
+        " If the file is new, append the current date
+        return a:url . '_' . strftime('%Y%m%d')
+      endif
+
+      return a:url
+    endfunction
+<
+  With the above setting, links created with |WikiOpen| will be transformed by
+  `MyFunction`. As an example, if one enters a page name "foo" on 2020-04-11,
+  the page "foo_20200411" will be created.
+
+  Default: ''
 ==============================================================================
 COMMANDS                                                        *wiki-commands*
 
@@ -365,7 +386,7 @@ possible.
 *WikiOpen*
   Open (or create) a page. Asks for user input to specify the page name. When
   not already inside a wiki, the wiki root is given by |g:wiki_root|. If
-  |g:wiki_link_target_map| is specified, it will be used to transform the
+  |g:wiki_page_create_map| is specified, it will be used to transform the
   input before opening/creating the page.
 
 *<plug>(wiki-journal)*

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -36,7 +36,7 @@ call wiki#init#option('wiki_filetypes', ['wiki'])
 call wiki#init#option('wiki_index_name', 'index')
 call wiki#init#option('wiki_root', '')
 call wiki#init#option('wiki_link_extension', '')
-call wiki#init#option('wiki_link_target_map', '')
+call wiki#init#option('wiki_map_link_target', '')
 call wiki#init#option('wiki_link_target_type', 'wiki')
 call wiki#init#option('wiki_month_names', [
       \ 'January', 'February', 'March', 'April', 'May', 'June', 'July',

--- a/test/test-common/test_links_open.vim
+++ b/test/test-common/test_links_open.vim
@@ -6,7 +6,7 @@ endfunction
 
 let g:wiki_filetypes = ['md']
 let g:wiki_link_extension = '.md'
-let g:wiki_link_target_map = 'MyFunction'
+let g:wiki_map_link_target = 'MyFunction'
 let g:wiki_root = expand('<sfile>:h') . '/ex1-basic'
 
 runtime plugin/wiki.vim

--- a/test/test-common/test_links_toggle.vim
+++ b/test/test-common/test_links_toggle.vim
@@ -1,6 +1,6 @@
 source ../init.vim
 
-let g:wiki_link_target_map = 'MyFunction'
+let g:wiki_map_link_target = 'MyFunction'
 
 function MyFunction(text) abort
   return substitute(tolower(a:text), '\s\+', '-', 'g')


### PR DESCRIPTION
Per discussion in #64, this PR adds a very simple implementation of an option to specify a function which will be invoked to transform the paths of pages created through `WikiOpen`.

One design point that may need more iteration is that this runs the function for **all** invocations of `WikiOpen` - it does not test that the page is being created (rather than opened) first, and leaves this to the user (as shown in the example added to the docs). This may be good enough, or it may be better to add logic to ensure that the transformation function is only run for new pages.