### PR TITLE
Add options to selectively enable only local/global default mappings

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -128,7 +128,7 @@ function! s:init_buffer_mappings() abort " {{{1
 
 
   let l:mappings = {}
-  if get(g:, 'wiki_mappings_use_all_defaults', 1) || get(g:, 'wiki_mappings_use_local_defaults', 0)
+  if index(['all', 'local'], g:wiki_mappings_use_defaults) >= 0
     let l:mappings = {
           \ '<plug>(wiki-code-run)' : '<leader>wc',
           \ '<plug>(wiki-graph-find-backlinks)' : '<leader>wb',

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -128,7 +128,7 @@ function! s:init_buffer_mappings() abort " {{{1
 
 
   let l:mappings = {}
-  if get(g:, 'wiki_mappings_use_defaults', 1)
+  if get(g:, 'wiki_mappings_use_all_defaults', 1) || get(g:, 'wiki_mappings_use_local_defaults', 0)
     let l:mappings = {
           \ '<plug>(wiki-code-run)' : '<leader>wc',
           \ '<plug>(wiki-graph-find-backlinks)' : '<leader>wb',

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -238,13 +238,31 @@ CONFIGURATION                                                     *wiki-config*
         \ },
         \}
 
-*g:wiki_mappings_use_defaults*
+
+*g:wiki_mappings_use_all_defaults*
   Whether or not to use default mappings (see |wiki-mappings-default|). If
+  Whether or not to use all default mappings (see |wiki-mappings-default|). If
+  this is set to 0, then only custom mappings will be applied. Custom mappings
   this is set to 0, then only custom mappings will be applied. Custom mappings
   may either be specified explicitly or through |g:wiki_mappings_global| and
+  may either be specified explicitly or through |g:wiki_mappings_global| and
+  |g:wiki_mappings_local|.
   |g:wiki_mappings_local|.
 
+
   Default: 1
+  Default: 1
+
+
+*g:wiki_mappings_use_global_defaults*
+*g:wiki_mappings_use_local_defaults*
+  Whether or not to use the global or local (respectively) default mappings (see
+  |wiki-mappings-default|). Setting one of these variables to 1 and setting
+  g:wiki_mappings_use_all_defaults to 0 allows you to only enable one set of
+  default mappings (e.g. if you want the wiki buffer mappings but not the global
+  mappings)
+
+  Default: 0
 
 *g:wiki_mappings_global*
 *g:wiki_mappings_local*
@@ -257,7 +275,7 @@ CONFIGURATION                                                     *wiki-config*
         \}
 <
   This example maps `,wx` to |<plug>(wiki-reload)|. The other maps are kept at
-  the default (unless |g:wiki_mappings_use_defaults| is set to 0). Some
+  the default (unless |g:wiki_mappings_use_all_defaults| is set to 0). Some
   mappings are defined in other modes than normal mode. In this case, one can
   use the following syntax: >
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -239,30 +239,15 @@ CONFIGURATION                                                     *wiki-config*
         \}
 
 
-*g:wiki_mappings_use_all_defaults*
-  Whether or not to use default mappings (see |wiki-mappings-default|). If
-  Whether or not to use all default mappings (see |wiki-mappings-default|). If
-  this is set to 0, then only custom mappings will be applied. Custom mappings
-  this is set to 0, then only custom mappings will be applied. Custom mappings
-  may either be specified explicitly or through |g:wiki_mappings_global| and
+*g:wiki_mappings_use_defaults*
+  Whether or not to use default mappings (see |wiki-mappings-default|). Allowed
+  values are 'all' (use all default mappings), 'local' (use only the
+  buffer-local default mappings), 'global' (use only the global default
+  mappings) and 'none' (do not use any of the default mappings). Custom mappings
   may either be specified explicitly or through |g:wiki_mappings_global| and
   |g:wiki_mappings_local|.
-  |g:wiki_mappings_local|.
 
-
-  Default: 1
-  Default: 1
-
-
-*g:wiki_mappings_use_global_defaults*
-*g:wiki_mappings_use_local_defaults*
-  Whether or not to use the global or local (respectively) default mappings (see
-  |wiki-mappings-default|). Setting one of these variables to 1 and setting
-  g:wiki_mappings_use_all_defaults to 0 allows you to only enable one set of
-  default mappings (e.g. if you want the wiki buffer mappings but not the global
-  mappings)
-
-  Default: 0
+  Default: 'all'
 
 *g:wiki_mappings_global*
 *g:wiki_mappings_local*
@@ -275,9 +260,9 @@ CONFIGURATION                                                     *wiki-config*
         \}
 <
   This example maps `,wx` to |<plug>(wiki-reload)|. The other maps are kept at
-  the default (unless |g:wiki_mappings_use_all_defaults| is set to 0). Some
-  mappings are defined in other modes than normal mode. In this case, one can
-  use the following syntax: >
+  the default (unless |g:wiki_mappings_use_defaults| is set to 'none' or
+  'local'). Some mappings are defined in other modes than normal mode. In this
+  case, one can use the following syntax: >
 
     let g:wiki_mappings_local = {
           \ '<plug>(wiki-list-toggle)' : '<c-w>',

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -68,7 +68,7 @@ nnoremap <silent> <plug>(wiki-fzf-pages) :WikiFzfPages<cr>
 nnoremap <silent> <plug>(wiki-fzf-tags)  :WikiFzfTags<cr>
 
 " Apply default mappings
-let s:mappings = get(g:, 'wiki_mappings_use_defaults', 1)
+let s:mappings = get(g:, 'wiki_mappings_use_all_defaults', 1) || get(g:, 'wiki_mappings_use_global_defaults', 0)
       \ ? {
       \ '<plug>(wiki-index)' : '<leader>ww',
       \ '<plug>(wiki-open)' : '<leader>wn',

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -48,6 +48,7 @@ call wiki#init#option('wiki_template_title_week',
 call wiki#init#option('wiki_template_title_month',
       \ '# Summary, %(year) %(month-name)')
 call wiki#init#option('wiki_zotero_root', '~/.local/zotero')
+call wiki#init#option('wiki_mappings_use_defaults', 'all')
 
 " Initialize global commands
 command! WikiEnable   call wiki#buffer#init()
@@ -68,7 +69,7 @@ nnoremap <silent> <plug>(wiki-fzf-pages) :WikiFzfPages<cr>
 nnoremap <silent> <plug>(wiki-fzf-tags)  :WikiFzfTags<cr>
 
 " Apply default mappings
-let s:mappings = get(g:, 'wiki_mappings_use_all_defaults', 1) || get(g:, 'wiki_mappings_use_global_defaults', 0)
+let s:mappings = index(['all', 'global'], g:wiki_mappings_use_defaults) >= 0
       \ ? {
       \ '<plug>(wiki-index)' : '<leader>ww',
       \ '<plug>(wiki-open)' : '<leader>wn',


### PR DESCRIPTION
This PR adds two configuration variables to allow users to choose a subset (local/global) of the default mappings to use. This is useful (to me, at least) because while the buffer-local mappings are nice to have, the global mappings interfere with existing keybindings in my config. I wasn't able to find a good way to enable only the local mappings (setting empty `lhs` values in `g:wiki_mappings_global` almost worked but caused strange `echo` output on loading the plugin); hence, this set of changes.