### PR TITLE
Add support for custom tag formats

### DIFF
--- a/autoload/wiki/tags.vim
+++ b/autoload/wiki/tags.vim
@@ -205,7 +205,7 @@ function! s:tags.gather_from_file(file) abort dict " {{{1
 
     while v:true
       let [l:tag, l:pos, l:col]
-            \ = matchstrpos(l:line, '\v%(^|\s):\zs[^: ]+\ze:', l:col)
+            \ = matchstrpos(l:line, g:wiki_tag_format_pattern, l:col)
       if l:col == -1 | break | endif
 
       call self.add(l:tag, a:file, l:lnum, l:pos)

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -353,6 +353,15 @@ CONFIGURATION                                                     *wiki-config*
         \ 'output' : 'loclist',
         }
 
+*g:wiki_tag_format_pattern*
+  A regular expression describing the search pattern for a single tag.
+
+  Default: >
+    let g:wiki_tag_format_pattern = '\v%(^|\s):\zs[^: ]+\ze:'
+
+  Example (to allow tags to be of the form "#tag1 #tag2"): >
+    let g:wiki_tag_format_pattern = '\v%(^|\s)#\zs[^# ]+\ze($| )'
+
 *g:wiki_template_title_month*
   A string that specifies the title of the month template. The following keys
   are interpolated:
@@ -825,10 +834,13 @@ style links (see |wiki-links|).
 ==============================================================================
 TAGS                                                                *wiki-tags*
 
-Wiki pages may be tagged with the syntax `:tag-name:` for a single tag or
-`:tag-one:tag-two:` for multiple tags. The tag name must consist of purely
-non-space characters. All tags added in the top 15 lines of a file will be
-recognized.
+Wiki pages may be tagged with keywords for organization. By default, tags use
+the syntax `:tag-name:` for a single tag or `:tag-one:tag-two:` for multiple
+tags. The tag name must consist of purely non-space characters. All tags added
+in the top 15 lines of a file will be recognized.
+
+You may customize the format of tags by modifying the
+|g:wiki_tag_format_pattern| variable.
 
 Related commands:
 - |WikiTagList|

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -31,6 +31,7 @@ call wiki#init#option('wiki_export', {
       \ 'output' : fnamemodify(tempname(), ':h'),
       \})
 call wiki#init#option('wiki_tags', { 'output' : 'loclist' })
+call wiki#init#option('wiki_tag_format_pattern', '\v%(^|\s):\zs[^: ]+\ze:')
 call wiki#init#option('wiki_filetypes', ['wiki'])
 call wiki#init#option('wiki_index_name', 'index')
 call wiki#init#option('wiki_root', '')


### PR DESCRIPTION
This PR adds a configuration variable `g:wiki_tag_format_pattern` to allow users to customize the format of their tags, e.g. if they would prefer a syntax like `#tag1 tag2` to the default `:tag1:tag2:`.

This PR is motivated by, when trying to use other editors for my Wiki files on platforms that do not support Vim (e.g. phones, etc.), running into a lack of support for VimWiki-style tags, though hashtag-tags are more broadly supported.

I've tested the example pattern to support that particular style of tag, and it seems to work correctly (e.g. it doesn't capture headers, link fragments, etc.), but I wouldn't be too surprised if I'd missed an edge case.

If you feel this is feature-creep/otherwise out of scope of the project, no problem.