### PR TITLE
Set text from URL if empty to avoid prepending `\`

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -317,9 +317,10 @@ function! wiki#link#template_word(url, ...) abort " {{{1
   "
   if !empty(g:wiki_map_link_create) && exists('*' . g:wiki_map_link_create)
     let l:url = call(g:wiki_map_link_create, [a:url])
-    if empty(l:text) && l:url !=# a:url
-      let l:text = a:url
-    endif
+  endif
+
+  if empty(l:text)
+    let l:text = a:url
   endif
 
   "

--- a/test/test-common/test_links_toggle.vim
+++ b/test/test-common/test_links_toggle.vim
@@ -47,4 +47,26 @@ normal! 3G
 silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
 call wiki#test#assert_equal('[This is a wiki](this-is-a-wiki.md).', getline('.'))
 
+" Test toggle normal on regular markdown links using md style links in journal
+bwipeout!
+let g:wiki_link_target_type = 'md'
+let g:wiki_link_extension = ''
+silent edit ex1-basic/index.wiki
+normal! 3G
+silent execute 'let b:wiki.in_journal=1'
+silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
+call wiki#test#assert_equal('[This is a wiki](/this-is-a-wiki).', getline('.'))
+
+" Test toggle normal on regular markdown links using md style links in journal
+" without `g:wiki_map_link_create`
+bwipeout!
+let g:wiki_link_target_type = 'md'
+let g:wiki_link_extension = ''
+let g:wiki_map_link_create = ''
+silent edit ex1-basic/index.wiki
+normal! 3G
+silent execute 'let b:wiki.in_journal=1'
+silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
+call wiki#test#assert_equal('[This is a wiki](/This is a wiki).', getline('.'))
+
 if $QUIT | quitall! | endif


### PR DESCRIPTION
Hi there!

First of all: thank you for the great work, I have been using `wiki.vim` for a couple of months and it's super useful.

I spotted a small bug in my daily usage. When in a journal page, toggling a Markdown link on a target would result in the text of the link having a leading slash (annoying). Specifically:

```
word -> [/word](/word)
```

As far as I have seen, this happens for single words and longer sentences, and it happened regardless of whether `g:wiki_map_link_create` was set or not. Only in journal pages.

I tracked the problem to this bit of code:

```vim
function! wiki#link#template_word(url, ...) abort " {{{1
 [...]
  "
  " Solve trivial cases first
  "
  if len(l:candidates) == 0
    return wiki#link#template_pick_from_option((b:wiki.in_journal ? '/' : '') . l:url, l:text)
  elseif len(l:candidates) == 1
  [...]
```

It is problematic as `l:text` is empty and gets the value of `l:url`, including the leading slash. 

I also added a couple of tests specific to this.