### PR TITLE
feat: write_on_nav option

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -142,6 +142,9 @@ function! wiki#link#open(...) abort "{{{1
 
   try
     if has_key(l:link, 'open')
+      if g:wiki_write_on_nav
+        update
+      endif
       call call(l:link.open, a:000, l:link)
     else
       call wiki#link#toggle(l:link)

--- a/autoload/wiki/nav.vim
+++ b/autoload/wiki/nav.vim
@@ -20,6 +20,10 @@ endfunction
 " }}}1
 
 function! wiki#nav#return() abort "{{{1
+  if g:wiki_write_on_nav
+    update
+  endif
+
   if !empty(s:position_stack)
     let [l:file, l:pos] = remove(s:position_stack, -1)
     silent execute ':e ' . substitute(l:file, '\s', '\\\0', 'g')

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -430,6 +430,16 @@ OPTIONS                                                   *wiki-config-options*
 
   Default: `'~/.local/zotero'`
 
+*g:wiki_write_on_nav*
+  Option to specify whether or not to save the current file automatically
+  before navigating (forward or backward) between wiki links.
+  
+  The default behavior prompts the user to manually save any changes made to
+  the current file before opening a wiki link or returning to a previously
+  visited link.
+
+  Default: 0
+  
 ------------------------------------------------------------------------------
 EVENTS                                                     *wiki-config-events*
 

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -50,6 +50,7 @@ call wiki#init#option('wiki_template_title_month',
       \ '# Summary, %(year) %(month-name)')
 call wiki#init#option('wiki_zotero_root', '~/.local/zotero')
 call wiki#init#option('wiki_mappings_use_defaults', 'all')
+call wiki#init#option('wiki_write_on_nav', 0)
 
 " Initialize global commands
 command! WikiEnable   call wiki#buffer#init()


### PR DESCRIPTION
_**what:**_ This pull request adds a config option to automatically save files before navigating between wiki links. 

_**why:**_ This is pretty useful for me since I often instinctively follow links even when I've made local changes. In that case, I'd rather the plugin just save the file automatically and follow the link, saving me the trouble of exiting the error message and saving the file manually.

_**how:**_ The proposed solution just sticks a check for the option (`g:wiki_write_on_nav`) in the `wiki#nav#return()` and `wiki#link#open()` functions, and calls `update` if the option is set.

_**testing:**_ I've had this change in my personal wiki for some time now without any hiccups. That said, the change is pretty simple and there may be some edge cases I didn't think about, so please let me know if there any obvious issues I overlooked.