### PR TITLE
fix: relative wiki link path expansion

### DIFF
--- a/autoload/wiki/url/wiki.vim
+++ b/autoload/wiki/url/wiki.vim
@@ -47,6 +47,9 @@ function! wiki#url#wiki#parse(url) abort " {{{1
     endif
   endif
 
+  " Fully expand (possibly relative) path
+  let l:url.path = fnamemodify(l:url.path, ':p')
+
   return l:url
 endfunction
 


### PR DESCRIPTION
_**what:**_ This is a one-line addition to fix relative path name expansion when following wiki links.

_**why**_: I use relative wiki link URLs to link notes across directories. For example, I might have the notes `wiki/dir1/note1.md` and `wiki/dir2/note2.md`. To reference `note2` from within `note1` (using Markdown-style links), I would have the link `[Note 2](../dir2/note2)`. However, when visiting the link, wiki.vim leaves the target path as `wiki/dir1/../dir2/note2.md`. This seems to be okay assuming the relative path notation is interpreted properly, but I've observed unexpected behavior at times. If nothing else, Vim will show the visited file path as `wiki/dir1/../dir2/note2.md` at the bottom of the editor, which is a bit odd to look at.

_**how:**_ The fix just makes sure the `url.path` attribute is fully expanded using `fnamemodify`.

_**testing**_: The expansion resolves the observed issue in the above scenario, ensuring the visited path is `wiki/dir2/note2.md`. All paths without relative components like `..` should remain the same as before, and I've had no issues with this change in my personal wiki for the last few months. 