### PR TITLE
Fix wiki-link-open-split mapping

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -141,7 +141,7 @@ function! s:init_buffer_mappings() abort " {{{1
           \ '<plug>(wiki-link-prev)' : '<s-tab>',
           \ '<plug>(wiki-link-show)' : '<leader>wll',
           \ '<plug>(wiki-link-open)' : '<cr>',
-          \ '<plug>(wiki-link-open-split)' : '<c-w><cr>',
+          \ '<plug>(wiki-link-open-split)' : '<c-cr>',
           \ '<plug>(wiki-link-return)' : '<bs>',
           \ '<plug>(wiki-link-toggle)' : '<leader>wf',
           \ '<plug>(wiki-link-toggle-operator)' : 'gl',


### PR DESCRIPTION
Hello.

For wiki-link-open-split, in the docs, `<c-cr>` is specified but in the actual code it had been mapped to `<c-w><cr>`.

Assuming that you're using mappings from VimWiki, I edited the mapping in the code to match that in the doc instead of the other way around.

Thanks for creating and maintaining vim.wiki!