### PR TITLE
Extend search for tags in files with all wiki extensions (issue #98)

### DIFF
--- a/autoload/wiki/tags.vim
+++ b/autoload/wiki/tags.vim
@@ -176,9 +176,11 @@ endfunction
 " }}}1
 function! s:tags.gather() abort dict " {{{1
   if !self.parsed
-    for l:file in globpath(wiki#get_root(),
-          \ '**/*.' . g:wiki_filetypes[0], 0, 1)
-      call self.gather_from_file(l:file)
+    for l:type in g:wiki_filetypes
+      for l:file in globpath(wiki#get_root(),
+          \ '**/*.' . l:type , 0, 1)
+        call self.gather_from_file(l:file)
+      endfor
     endfor
     let self.parsed = 1
   endif


### PR DESCRIPTION
My proposal to address issue #98 . Seems to search for tags in all files.  It appears to fix the problem also for the FzF tag search, which apparently uses the same tag list.