### PR TITLE
Link Extension Replace for WikiExport

### DIFF
--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -308,6 +308,8 @@ function! wiki#page#export(line1, line2, ...) abort " {{{1
       let l:cfg.ext = remove(l:args, 0)
     elseif l:arg ==# '-output'
       let l:cfg.output = remove(l:args, 0)
+    elseif l:arg ==# '-link-extension-replace'
+      let l:cfg.link_replace = v:true
     elseif l:arg ==# '-view'
       let l:cfg.view = v:true
     elseif l:arg ==# '-viewer'

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -308,8 +308,8 @@ function! wiki#page#export(line1, line2, ...) abort " {{{1
       let l:cfg.ext = remove(l:args, 0)
     elseif l:arg ==# '-output'
       let l:cfg.output = remove(l:args, 0)
-    elseif l:arg ==# '-link-ext-replace'
-      let l:cfg.link_replace = v:true
+    elseif l:arg ==# '-link_ext_replace'
+      let l:cfg.link_ext_replace = v:true
     elseif l:arg ==# '-view'
       let l:cfg.view = v:true
     elseif l:arg ==# '-viewer'
@@ -474,7 +474,7 @@ function! s:export(start, end, cfg) abort " {{{1
   " Parse wiki page content
   let l:lines = getline(a:start, a:end)
 " Replace link extensions with .html if desired
-  if a:cfg.link_replace
+  if a:cfg.link_ext_replace
     " Regex requires that links end with '.', even when wiki_link_extension is
     " empty.
     if g:wiki_link_target_type ==# 'md'

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -468,13 +468,7 @@ endfunction
 
 " }}}1
 
-function! s:export(start, end, cfg) abort " {{{1
-  let l:fwiki = expand('%:p') . '.tmp'
-
-  " Parse wiki page content
-  let l:lines = getline(a:start, a:end)
-" Replace link extensions with .html if desired
-  if a:cfg.link_ext_replace
+function! s:convert_links_html(lines) abort
     " Regex requires that links end with '.', even when wiki_link_extension is
     " empty.
     if g:wiki_link_target_type ==# 'md'
@@ -488,10 +482,23 @@ function! s:export(start, end, cfg) abort " {{{1
       let l:link_rx = l:link_rx . '|\([^\[\]\\]\{-}\)\]\]'
       let l:pattern = '\[\[\1.html\2|\3\]\]'
     else
-      echoerr 'Unsupported link type for export replacement'
+      let l:err = 'g:wiki_link_target_type must be `md` or `wiki` to replace '
+      let l:err = l:err . 'link extensions on export.'
+      echoerr l:err
       return
     endif
-    call map(l:lines, 'substitute(v:val, l:link_rx, l:pattern, ''g'')')
+    call map(a:lines, 'substitute(v:val, l:link_rx, l:pattern, ''g'')')
+    return a:lines
+endfunction
+
+function! s:export(start, end, cfg) abort " {{{1
+  let l:fwiki = expand('%:p') . '.tmp'
+
+  " Parse wiki page content
+  let l:lines = getline(a:start, a:end)
+" Replace link extensions with .html if desired
+  if a:cfg.link_ext_replace
+    let l:lines = s:convert_links_html(l:lines)
   endif
 
   let l:wiki_link_rx = '\[\[#\?\([^\\|\]]\{-}\)\]\]'

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -402,7 +402,7 @@ OPTIONS                                                   *wiki-config-options*
         \ 'args' : '',
         \ 'from_format' : 'markdown',
         \ 'ext' : 'pdf',
-        \ 'link-extension-replace': v:false,
+        \ 'link_ext_replace': v:false,
         \ 'view' : v:false,
         \ 'output': fnamemodify(tempname(), ':h'),
         \}
@@ -663,9 +663,10 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   -ext EXT~
     Specify extension to use if `fname` is not provided.
 
-  -link-extension-replace~
+  -link_ext_replace~
     Set to true to replace in-wiki link extensions with html. This enables
-    in-browser wiki navigation. Requires`ext` be set to html.
+    in-browser wiki navigation. Requires`ext` be set to `html` and for
+    `g:wiki_link_extension` to be non-empty to have any meaningful effect.
 
   -output~
     Set output directory where the exported file is stored. Relative paths are

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -665,8 +665,8 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 
   -link_ext_replace~
     Set to true to replace in-wiki link extensions with html. This enables
-    in-browser wiki navigation. Requires`ext` be set to `html` and for
-    `g:wiki_link_extension` to be non-empty to have any meaningful effect.
+    in-browser wiki navigation. Requires `ext` be set to `html` and for
+    |g:wiki_link_extension| to be non-empty to have any meaningful effect.
 
   -output~
     Set output directory where the exported file is stored. Relative paths are

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -402,6 +402,7 @@ OPTIONS                                                   *wiki-config-options*
         \ 'args' : '',
         \ 'from_format' : 'markdown',
         \ 'ext' : 'pdf',
+        \ 'link-extension-replace': v:false,
         \ 'view' : v:false,
         \ 'output': fnamemodify(tempname(), ':h'),
         \}
@@ -662,6 +663,10 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   -ext EXT~
     Specify extension to use if `fname` is not provided.
 
+  -link-extension-replace~
+    Set to true to replace in-wiki link extensions with html. This enables
+    in-browser wiki navigation. Requires`ext` be set to html.
+
   -output~
     Set output directory where the exported file is stored. Relative paths are
     relative to the wiki root.
@@ -673,7 +678,7 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
     Specify viewer to use to open the exported file. This implies `-view` and
     overrides the |g:wiki_viewer| option.
 
-  Note: This feature requires `pandoc` (https://pandoc.org/) to build the 
+  Note: This feature requires `pandoc` (https://pandoc.org/) to build the
         output files.
 
 *<plug>(wiki-tag-list)*


### PR DESCRIPTION
First pass solution for #100, the argparse section `page.vim:300` wasn't having any effect (arguments seemed to be empty, though that seems like a config issue). Let me know what you think -- happy to make changes.

Some notes:
* This enforces a markdown or mediawiki link style syntax, but I didn't see any indication that other link formats were supported. If they are, I can add other regex or we can go in a different direction.
* This matches links that end with an extension `.md` or `.wiki`, it won't work meaningfully if `g:wiki_link_extension`is empty (this can change as well)

@lervag 