### PR TITLE
Allow WikiPageRename to move the page to another directory (including creating the directory)

### DIFF
--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -95,7 +95,7 @@ function! wiki#page#rename(newname) abort "{{{1
   for l:bufname in l:bufs
     execute 'buffer' fnameescape(l:bufname)
     update
-   execute 'bwipeout' fnameescape(l:bufname)
+    execute 'bwipeout' fnameescape(l:bufname)
   endfor
   let b:wiki = l:wiki
 
@@ -127,13 +127,13 @@ function! wiki#page#rename_ask() abort "{{{1
   let l:name = input('> ')
   
   " Check if directory exists
-  let l:newpath = printf('%s/%s', expand('%:h'), l:name)
-  let l:target_dir = simplify(fnamemodify(expand(l:newpath), ':h'))
+  let l:target_dir = fnamemodify(
+    \ simplify(printf('%s/%s', expand('%:p:h'), l:name)), ":p:h")
   if !isdirectory(l:target_dir)
     redraw!
     echo "Directory '" . l:target_dir . "' does not exist. "
     if input("Create [Y]es/[n]o ? ", "Y") !=? "y"
-        return
+      return
     endif
     call mkdir(l:target_dir, "p")
   endif 

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -39,8 +39,8 @@ endfunction
 function! wiki#page#rename(newname) abort "{{{1
   redraw!
   let l:oldpath = expand('%:p')
-  let l:newpath = printf('%s/%s.%s',
-        \ expand('%:p:h'), a:newname, b:wiki.extension)
+  let l:newpath = simplify(printf('%s/%s.%s',
+        \ expand('%:p:h'), a:newname, b:wiki.extension))
 
   " Check if current file exists
   if !filereadable(l:oldpath)
@@ -95,7 +95,7 @@ function! wiki#page#rename(newname) abort "{{{1
   for l:bufname in l:bufs
     execute 'buffer' fnameescape(l:bufname)
     update
-    execute 'bwipeout' fnameescape(l:bufname)
+   execute 'bwipeout' fnameescape(l:bufname)
   endfor
   let b:wiki = l:wiki
 
@@ -120,15 +120,15 @@ function! wiki#page#rename_ask() abort "{{{1
   if input('Rename "' . expand('%:t:r') . '" [y]es/[N]o? ') !~? '^y'
     return
   endif
-  
+
   " Get new page name
   redraw!
   echo 'Enter new name (without extension):'
   let l:name = input('> ')
   
-  " Check if directory if it does not exist
-  let l:newpath = printf('%s/%s', expand('%:p:h'), l:name)
-  let l:target_dir = fnamemodify(expand(l:newpath), ':h')
+  " Check if directory exists
+  let l:newpath = printf('%s/%s', expand('%:h'), l:name)
+  let l:target_dir = simplify(fnamemodify(expand(l:newpath), ':h'))
   if !isdirectory(l:target_dir)
     redraw!
     echo "Directory '" . l:target_dir . "' does not exist. "

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -68,6 +68,14 @@ function! wiki#page#rename(newname) abort "{{{1
     return
   endif
 
+  " The target directory must exist
+  let l:target_dir = fnamemodify (expand (l:newpath), ':h')
+  if !isdirectory (l:target_dir)
+    echom 'wikiError: Cannot rename to "' . l:newpath . '".
+          \ Target directory "' . l:target_dir . '" does not exist!'
+    return
+  endif
+
   " Rename current file to l:newpath
   try
     echom printf('wiki: Renaming "%s" to "%s"',

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -68,20 +68,12 @@ function! wiki#page#rename(newname) abort "{{{1
     return
   endif
 
-  " The target directory must exist
-  let l:target_dir = fnamemodify (expand (l:newpath), ':h')
-  if !isdirectory (l:target_dir)
-    echom 'wikiError: Cannot rename to "' . l:newpath . '".
-          \ Target directory "' . l:target_dir . '" does not exist!'
-    return
-  endif
-
   " Rename current file to l:newpath
   try
     echom printf('wiki: Renaming "%s" to "%s"',
           \ expand('%:t') , fnamemodify(l:newpath, ':t'))
     if rename(l:oldpath, l:newpath) != 0
-      throw 'Cannot rename!'
+      throw 'wiki.vim: Cannot rename file!'
     end
   catch
     echom printf('wiki Error: Cannot rename "%s" to "%s"',
@@ -128,11 +120,24 @@ function! wiki#page#rename_ask() abort "{{{1
   if input('Rename "' . expand('%:t:r') . '" [y]es/[N]o? ') !~? '^y'
     return
   endif
-
+  
   " Get new page name
   redraw!
   echo 'Enter new name (without extension):'
   let l:name = input('> ')
+  
+  " Check if directory if it does not exist
+  let l:newpath = printf('%s/%s', expand('%:p:h'), l:name)
+  let l:target_dir = fnamemodify(expand(l:newpath), ':h')
+  if !isdirectory(l:target_dir)
+    redraw!
+    echo "Directory '" . l:target_dir . "' does not exist. "
+    if input("Create [Y]es/[n]o ? ", "Y") !=? "y"
+        return
+    endif
+    call mkdir(l:target_dir, "p")
+  endif 
+
   call wiki#page#rename(l:name)
 endfunction
 

--- a/test/test-page/test-move.vim
+++ b/test/test-page/test-move.vim
@@ -9,7 +9,7 @@ call wiki#test#assert_equal(
       \ expand('%:p'))
 
 silent edit wiki-tmp/index.wiki
-silent call wiki#page#rename('nosubdir/index')
+call wiki#page#rename('nosubdir/index')
 call wiki#test#assert_equal(
       \ expand('<sfile>:h') . '/wiki-tmp/nosubdir/index.wiki',
       \ expand('%:p'))

--- a/test/test-page/test-move.vim
+++ b/test/test-page/test-move.vim
@@ -1,0 +1,16 @@
+source ../init.vim
+runtime plugin/wiki.vim
+
+silent edit wiki-tmp/BadName.wiki
+
+silent call wiki#page#rename('subdir/GoodName')
+call wiki#test#assert_equal(
+      \ expand('<sfile>:h') . '/wiki-tmp/subdir/GoodName.wiki',
+      \ expand('%:p'))
+
+silent edit wiki-tmp/index.wiki
+silent call wiki#page#rename('nosubdir/index')
+call wiki#test#assert_equal(
+      \ expand('<sfile>:h') . '/wiki-tmp/nosubdir/index.wiki',
+      \ expand('%:p'))
+quitall!

--- a/test/test-page/test-move.vim
+++ b/test/test-page/test-move.vim
@@ -8,9 +8,4 @@ call wiki#test#assert_equal(
       \ expand('<sfile>:h') . '/wiki-tmp/subdir/GoodName.wiki',
       \ expand('%:p'))
 
-silent edit wiki-tmp/index.wiki
-call wiki#page#rename('nosubdir/index')
-call wiki#test#assert_equal(
-      \ expand('<sfile>:h') . '/wiki-tmp/nosubdir/index.wiki',
-      \ expand('%:p'))
 quitall!


### PR DESCRIPTION
These are two tests that demonstrate how WikiPageRename works for moving pages around.  It succeeds if target dir exists and fails if target dir does not exist.  These tests are supporting discussion in issue #107 