### PR TITLE
Support for Asciidoctor style of links

### DIFF
--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -145,6 +145,27 @@ function! s:completer_mdlink.findstart(line) dict abort " {{{2
 endfunction
 
 " }}}1
+" {{{1 AdocLink
+
+let s:completer_adoclink = deepcopy(s:completer_wikilink)
+
+function! s:completer_adoclink.findstart(line) dict abort " {{{2
+  let l:cnum = match(a:line, '<<\zs[^,]\{-}')
+  if l:cnum < 0 | return -1 | endif
+
+  let l:base = a:line[l:cnum:]
+
+  let self.rooted = l:base[0] ==# '/'
+
+  " completing of anchors is disabled because they won't be found for asciidoc
+  " anyway: wiki#rx#header_items regex is uded for search of anchors and it
+  " requires Markdown-style headers. This could be resolved by passing a
+  " specific regular expression to wiki#page#get_anchors()
+  let self.is_anchor = 0
+  return l:cnum
+endfunction
+
+" }}}1
 " {{{1 Zotero
 
 let s:completer_zotero = {}

--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -7,6 +7,7 @@
 function! wiki#link#get() abort " {{{1
   for l:matcher in [
         \ wiki#link#wiki#matcher(),
+        \ wiki#link#adoc#matcher(),
         \ wiki#link#md_fig#matcher(),
         \ wiki#link#md#matcher(),
         \ wiki#link#ref_target#matcher(),
@@ -33,6 +34,7 @@ function! wiki#link#get_all(...) abort "{{{1
 
   let l:matchers = [
         \ wiki#link#wiki#matcher(),
+        \ wiki#link#adoc#matcher(),
         \ wiki#link#md_fig#matcher(),
         \ wiki#link#md#matcher(),
         \ wiki#link#ref_target#matcher(),

--- a/autoload/wiki/link/adoc.vim
+++ b/autoload/wiki/link/adoc.vim
@@ -8,14 +8,14 @@ function! wiki#link#adoc#matcher() abort " {{{1
   return {
         \ 'type' : 'adoc',
         \ 'rx' : g:wiki#rx#link_adoc,
-        \ 'rx_url' : '<<\zs[^#]\{-}\ze#,[^>]\{-}>>',
+        \ 'rx_url' : '<<\zs[^#]\{-}\ze.adoc#,[^>]\{-}>>',
         \ 'rx_text' : '<<[^#]\{-}#,\zs[^>]\{-}\ze>>',
         \}
 endfunction
 
 " }}}1
 function! wiki#link#adoc#template(url, text) abort " {{{1
-  return printf('<<%s.adoc#,%s>>', empty(a:text) ? a:url : a:text, a:url)
+  return printf('<<%s.adoc#,%s>>', a:url, empty(a:text) ? a:url : a:text)
 endfunction
 
 " }}}1

--- a/autoload/wiki/link/adoc.vim
+++ b/autoload/wiki/link/adoc.vim
@@ -1,0 +1,21 @@
+" A simple wiki plugin for Vim
+"
+" Maintainer: Karl Yngve Lervåg
+" Email:      karl.yngve@gmail.com
+"
+
+function! wiki#link#adoc#matcher() abort " {{{1
+  return {
+        \ 'type' : 'adoc',
+        \ 'rx' : g:wiki#rx#link_adoc,
+        \ 'rx_url' : '<<\zs[^#]\{-}\ze#,[^>]\{-}>>',
+        \ 'rx_text' : '<<[^#]\{-}#,\zs[^>]\{-}\ze>>',
+        \}
+endfunction
+
+" }}}1
+function! wiki#link#adoc#template(url, text) abort " {{{1
+  return printf('<<%s.adoc#,%s>>', empty(a:text) ? a:url : a:text, a:url)
+endfunction
+
+" }}}1

--- a/autoload/wiki/rx.vim
+++ b/autoload/wiki/rx.vim
@@ -36,6 +36,7 @@ let wiki#rx#url = '\<\l\+:\%(\/\/\)\?[^ \t()\[\]|]\+'
 let wiki#rx#reftext = '[^\\\[\]]\{-}'
 let wiki#rx#reftarget = '\%(\d\+\|\a[-_. [:alnum:]]\+\)'
 let wiki#rx#link_md = '\[[^\\\[\]]\{-}\]([^\\]\{-})'
+let wiki#rx#link_adoc = '<<[^#]\{-}#,[^>]\{-}>>'
 let wiki#rx#link_md_fig = '!' . wiki#rx#link_md
 let wiki#rx#link_ref_single = '[\]\[]\@<!\[' . wiki#rx#reftarget . '\][\]\[]\@!'
 let wiki#rx#link_ref_double =
@@ -49,6 +50,7 @@ let wiki#rx#link_shortcite = '\%(\s\|^\|\[\)\zs@[-_a-zA-Z0-9]\+\>'
 let wiki#rx#link_wiki = '\[\[\/\?[^\\\]]\{-}\%(|[^\\\]]\{-}\)\?\]\]'
 let wiki#rx#link = join([
       \ wiki#rx#link_wiki,
+      \ wiki#rx#link_adoc,
       \ '!\?' . wiki#rx#link_md,
       \ wiki#rx#link_ref_target,
       \ wiki#rx#link_ref_single,

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -228,9 +228,10 @@ OPTIONS                                                   *wiki-config-options*
 *g:wiki_link_target_type*
   This option may be used to pick the default style of link that will be used.
 
-  Setting this to `md` will cause Markdown style links to be added by default,
-  rather than `wiki` style links. Toggling between link types can still be
-  achieved using |WikiLinkToggle|.
+  Available styles are `md` which will cause Markdown style links to be added
+  by default, `adoc` - Asciidoc inter-page cross reference style links and
+  `wiki` style links. Toggling between link types can still be achieved using
+  |WikiLinkToggle|.
 
   Default: 'wiki'
 
@@ -830,6 +831,8 @@ These are the link formats that are currently supported:
     `[Description][Target]`
 - Zotero shortlink                   |wiki-link-zotero|
     `@citekey`
+- Asciidoc links                     |wiki-link-adoc|
+    `<<URL#,Description>>`
 
 ------------------------------------------------------------------------------
 LINK URLS                                                      *wiki-link-url*
@@ -959,6 +962,14 @@ ZOTERO SHORLINKS                                             *wiki-link-zotero*
 As a minor convenience link type, Zotero URLs may be written in short as
 `@citekey` instead of `zot:citekey`. See also |wiki-link-url| for more info on
 the Zotero URL scheme and handler.
+
+------------------------------------------------------------------------------
+ASCIIDOC LINKSSHORLINKS                                        *wiki-link-adoc*
+
+Asciidoc links use Asciidoctor's Inter-document Cross References syntax and
+look like this: >
+
+  <<URL#,Description>>
 
 ==============================================================================
 LISTS                                                              *wiki-lists*

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -964,7 +964,7 @@ As a minor convenience link type, Zotero URLs may be written in short as
 the Zotero URL scheme and handler.
 
 ------------------------------------------------------------------------------
-ASCIIDOC LINKSSHORLINKS                                        *wiki-link-adoc*
+ASCIIDOC LINKS                                                 *wiki-link-adoc*
 
 Asciidoc links use Asciidoctor's Inter-document Cross References syntax and
 look like this: >

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -53,6 +53,7 @@ call wiki#init#option('wiki_mappings_use_defaults', 'all')
 call wiki#init#option('wiki_write_on_nav', 0)
 call wiki#init#option('wiki_link_toggles', {
       \ 'md': 'wiki#link#wiki#template',
+      \ 'adoc': 'wiki#link#adoc#template',
       \ 'wiki': 'wiki#link#md#template',
       \ 'date': 'wiki#link#wiki#template',
       \ 'shortcite': 'wiki#link#md#template',

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -52,9 +52,9 @@ call wiki#init#option('wiki_zotero_root', '~/.local/zotero')
 call wiki#init#option('wiki_mappings_use_defaults', 'all')
 call wiki#init#option('wiki_write_on_nav', 0)
 call wiki#init#option('wiki_link_toggles', {
-      \ 'md': 'wiki#link#wiki#template',
-      \ 'adoc': 'wiki#link#adoc#template',
       \ 'wiki': 'wiki#link#md#template',
+      \ 'md': 'wiki#link#adoc#template',
+      \ 'adoc': 'wiki#link#wiki#template',
       \ 'date': 'wiki#link#wiki#template',
       \ 'shortcite': 'wiki#link#md#template',
       \ 'url': 'wiki#link#md#template',


### PR DESCRIPTION
This implements Asciidoctor Inter-Page Cross References style links:

```
<<file.adoc#,title>>
```

Implemented things:
- ordinary links things (creating, following, regular expresssions for parsing etc.)
- links toggling (wiki -> md -> adoc -> wiki)
- omni function (without anchors; regular expression for finding anchors is hardcoded in `get_anchors` function and creating a single regex for Asciidoc, next to `g:wiki#rx#header_items` feels hacky)

Fixes #109 