### PR TITLE
Added option to not toggle links with WikiLinkOpen

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -120,7 +120,7 @@ function! wiki#link#open(...) abort "{{{1
     if has_key(l:link, 'open')
       if g:wiki_write_on_nav | update | endif
       call call(l:link.open, a:000, l:link)
-    else
+    elseif g:wiki_link_toggle_on_open
       call wiki#link#toggle(l:link)
     endif
   catch /E37:/

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -225,6 +225,11 @@ OPTIONS                                                   *wiki-config-options*
 
   Default: ''
 
+*g:wiki_link_toggle_on_open*
+  If set, transform text into links with |WikiLinkOpen|
+
+  Default: 1
+
 *g:wiki_link_target_type*
   This option may be used to pick the default style of link that will be used.
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -226,7 +226,9 @@ OPTIONS                                                   *wiki-config-options*
   Default: ''
 
 *g:wiki_link_toggle_on_open*
-  If set, transform text into links with |WikiLinkOpen|
+  This option allows to disable the toggle behaviour in |WikiLinkOpen| where
+  "normal" text is transformed into links. One may always use |WikiLinkToggle|
+  to transform text into links.
 
   Default: 1
 

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -40,6 +40,7 @@ call wiki#init#option('wiki_root', '')
 call wiki#init#option('wiki_map_link_create', '')
 call wiki#init#option('wiki_map_create_page', '')
 call wiki#init#option('wiki_link_extension', '')
+call wiki#init#option('wiki_link_toggle_on_open', 1)
 call wiki#init#option('wiki_link_target_type', 'wiki')
 call wiki#init#option('wiki_month_names', [
       \ 'January', 'February', 'March', 'April', 'May', 'June', 'July',


### PR DESCRIPTION
So, I often press enter when my cursor is over a header (`##`) or a bullet (`-` or `*`) and wiki.vim turns that WORD into a link. As `wiki#link#open` toggles the link, there isn't a suitable remapping for `<CR>`, so I added an option. 