### PR TITLE
fix: echo error but don't return

### DIFF
--- a/autoload/wiki/graph.vim
+++ b/autoload/wiki/graph.vim
@@ -171,7 +171,7 @@ function! s:gather_nodes() abort " {{{1
     endif
 
     if has_key(l:gathered, l:node)
-      return wiki#log#error('Not implemented!')
+      call wiki#log#error('Not implemented!')
     endif
 
     let l:gathered[l:node] = l:current

--- a/autoload/wiki/graph.vim
+++ b/autoload/wiki/graph.vim
@@ -170,10 +170,6 @@ function! s:gather_nodes() abort " {{{1
       endfor
     endif
 
-    if has_key(l:gathered, l:node)
-      call wiki#log#error('Not implemented!')
-    endif
-
     let l:gathered[l:node] = l:current
   endfor
 
@@ -202,7 +198,7 @@ let s:nodes = {}
 
 " }}}1
 function! s:file_to_node(file) abort " {{{1
-  return fnamemodify(a:file, ':t:r')
+  return fnamemodify(wiki#paths#shorten_relative(a:file), ':r')
 endfunction
 
 " }}}1

--- a/autoload/wiki/url.vim
+++ b/autoload/wiki/url.vim
@@ -35,7 +35,7 @@ function! wiki#url#parse(string, ...) abort " {{{1
   endif
 
   try
-    call extend(l:url, wiki#url#{l:url.scheme}#parse(l:url))
+    call extend(l:url, wiki#url#{tolower(l:url.scheme)}#parse(l:url))
   catch /E117:/
     call extend(l:url, wiki#url#generic#parse(l:url))
   endtry


### PR DESCRIPTION
Prior to this fix, I would get the following error when running `:WikiGraphFindBacklinks`:

```
wiki: Scanning wiki graph nodes ...
wiki: Not implemented!
Error detected while processing function wiki#graph#find_backlinks[6]..12:
line    1:
E712: Argument of get() must be a List or Dictionary
Press ENTER or type command to continue
```

It looks like during the recent refactor to logging (https://github.com/lervag/wiki.vim/commit/97e8d8b26f890c5ac5ba7c97290160118536d2ea), the `gather_nodes` function returned an error even when it isn't (or doesn't appear to be, at least) a fatal error.

With this change just echoing the error doesn't block the rest of the function completing and properly shows the backlinks.