### PR TITLE
Create new page with fzf even if there is a match

### DIFF
--- a/autoload/wiki/fzf.vim
+++ b/autoload/wiki/fzf.vim
@@ -17,10 +17,12 @@ function! wiki#fzf#pages() abort "{{{1
   let l:pages = globpath(l:root, l:pattern, v:false, v:true)
   call map(l:pages, '"/" . substitute(v:val, l:root . "/" , "", "")')
   call map(l:pages, {_, x -> x . "¤" . fnamemodify(x, ':r')})
+
   let fzf_opts = join([
         \ '-d"¤" --with-nth=-1 --print-query --prompt "WikiPages> "',
-        \ '--expect=alt-enter'
+        \ '--expect=' . get(g:, 'wiki_fzf_pages_force_create_key', 'alt-enter')
         \])
+
   call fzf#run(fzf#wrap({
         \ 'source': l:pages,
         \ 'sink*': funcref('s:accept_page'),
@@ -86,11 +88,7 @@ function! s:accept_page(lines) abort "{{{1
   " either empty or alt-enter, depending on if enter or alt-enter was used to
   " select, and the third line (possibly) contains the selection
   if len(a:lines) == 2 || !empty(a:lines[1])
-    let l:page = a:lines[0]
-    redraw!
-    call wiki#log#info('Opening page "' . l:page . '"')
-    sleep 1
-    call wiki#page#open(l:page)
+    call wiki#page#open(a:lines[0])
   else
     let l:file = split(a:lines[2], '¤')[0]
     execute 'edit ' . wiki#get_root() . l:file

--- a/autoload/wiki/fzf.vim
+++ b/autoload/wiki/fzf.vim
@@ -18,7 +18,7 @@ function! wiki#fzf#pages() abort "{{{1
   call map(l:pages, '"/" . substitute(v:val, l:root . "/" , "", "")')
   call map(l:pages, {_, x -> x . "¤" . fnamemodify(x, ':r')})
 
-  let fzf_opts = join([
+  let l:fzf_opts = join([
         \ '-d"¤" --with-nth=-1 --print-query --prompt "WikiPages> "',
         \ '--expect=' . get(g:, 'wiki_fzf_pages_force_create_key', 'alt-enter')
         \])
@@ -26,7 +26,7 @@ function! wiki#fzf#pages() abort "{{{1
   call fzf#run(fzf#wrap({
         \ 'source': l:pages,
         \ 'sink*': funcref('s:accept_page'),
-        \ 'options': fzf_opts
+        \ 'options': l:fzf_opts
         \}))
 endfunction
 

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -17,7 +17,7 @@ function! wiki#page#open(page) abort "{{{1
     sleep 1
   end
 
-  call url.open()
+  call l:url.open()
 endfunction
 
 "}}}1

--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -9,7 +9,15 @@ function! wiki#page#open(page) abort "{{{1
         \ !empty(g:wiki_map_create_page) && exists('*' . g:wiki_map_create_page)
         \ ? call(g:wiki_map_create_page, [a:page])
         \ : a:page
-  call wiki#url#parse('wiki:/' . l:page).open()
+  let l:url = wiki#url#parse('wiki:/' . l:page)
+
+  if !filereadable(l:url.path)
+    redraw!
+    call wiki#log#info('Opening new page "' . l:page . '"')
+    sleep 1
+  end
+
+  call url.open()
 endfunction
 
 "}}}1

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -505,6 +505,14 @@ OPTIONS                                                   *wiki-config-options*
 
   Default: 0
 
+*g:wiki_fzf_pages_force_create_key*
+  Key combination that, when pressed while searching with |WikiFzfPages|, will
+  create a new page with the name of the query. The value must be a string
+  recognized by fzf's `--expect` argument; see fzf's manual page for a list of
+  available keys.
+
+  Default: `'alt-enter'`
+
 ------------------------------------------------------------------------------
 EVENTS                                                     *wiki-config-events*
 
@@ -750,13 +758,18 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   Open |fzf| in find file mode for wiki files in current wiki or in the main
   wiki defined by |g:wiki_root|.
 
-  This can also also be used to create a new page. If a query is typed and
-  alt-enter is pressed, a new page with name equal to the query will be
-  created if it doesn't already exist. For example, suppose you search for "My
-  Fzf Page", and there is already a page named "My Favorite Fzf Page". fzf
-  will show the latter as a possible selection. If the enter key is pressed,
-  the existing "My Favorite Fzf Page" will be opened. If alt-enter is pressed
-  instead, a new page titled "My Fzf Page" will be created and opened.
+  This can also be used to create a new page. If a query is typed and the key
+  specified by |g:wiki_fzf_pages_force_create_key| is pressed (alt-enter, by
+  default), a page whose name is equal to the query will be created if it
+  doesn't already exist. If the page does already exist, it will be opened.
+  If |g:wiki_map_create_page| is defined, the new page name is determined by
+  first applying that function to the query.
+
+  For example, suppose you search for "foo", and there is one result: an
+  already-existing page named "foobar". If the enter key is pressed, the
+  existing "foobar" will be opened, as usual. However, if
+  |g:wiki_fzf_pages_force_create_key| is pressed instead, a new page titled
+  "foo" will be created and opened.
 
   For convenience, if the input query does not have any results, simply
   pressing enter will also create a page.  E.g., if you searched for "My Fzf

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -750,11 +750,18 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   Open |fzf| in find file mode for wiki files in current wiki or in the main
   wiki defined by |g:wiki_root|.
 
-  This can also also be used to create a new page similar to |WikiOpen|, if
-  the input search term does not have any results. E.g., if you searched for
-  "My Fzf Page", and this term does not exist, then it will instead open a new
-  page "My Fzf Page.wiki" (or similar, depending on the value of other
-  options).
+  This can also also be used to create a new page. If a query is typed and
+  alt-enter is pressed, a new page with name equal to the query will be
+  created if it doesn't already exist. For example, suppose you search for "My
+  Fzf Page", and there is already a page named "My Favorite Fzf Page". fzf
+  will show the latter as a possible selection. If the enter key is pressed,
+  the existing "My Favorite Fzf Page" will be opened. If alt-enter is pressed
+  instead, a new page titled "My Fzf Page" will be created and opened.
+
+  For convenience, if the input query does not have any results, simply
+  pressing enter will also create a page.  E.g., if you searched for "My Fzf
+  Page", and this term does not exist, then it will instead open a new page
+  "My Fzf Page.wiki" (or similar, depending on the value of other options).
 
 *<plug>(wiki-fzf-tags)*
 *WikiFzfTags*


### PR DESCRIPTION
Previously, `fzf#pages` was only capable of creating a new wiki page if the query results in no matches. This commit allows for the creation of a new page even when the query does match one or more existing pages by pressing alt-enter while in the fzf prompt.

My typical use case for `fzf#pages` is to search for a page and open it if it exists -- otherwise, create it. I often find myself in a situation where the page I'm looking for doesn't exist, but my query *does* match some existing unrelated page, and so I cannot create the new page with `fzf#pages`. For example, I'm trying to create a page named `test`, but there's a page named `technical support` (which matches due to having t,e,s,t, in that order).

This pull request uses fzf's `--expect` to allow the user to "force create" a page with the provided query as the name by pressing alt-enter instead of enter. I have left the original behavior, but in principle it could be removed to provide for a more consistent user experience. I have hardcoded the keybinding to avoid introducing more configuration, but it can be made customizable.