### PR TITLE
fix: prevent duplicate tag list on reload

### DIFF
--- a/autoload/wiki/tags.vim
+++ b/autoload/wiki/tags.vim
@@ -172,6 +172,7 @@ endfunction
 " }}}1
 function! s:tags.reload() abort dict " {{{1
   let self.parsed = 0
+  let self.collection = {}
   call self.gather()
 endfunction
 


### PR DESCRIPTION
Running `WikiTagReload` would produce a duplicate list of tag references in `WikiTagSearch`. Each time running `WikiTagReload` would add another repeated set to the search results.

This patch resets the collection to an empty list when running `WikiTagReload`.