### PR TITLE
feat: add graph search to check for broken links

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -39,6 +39,7 @@ endfunction
 function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiCodeRun            call wiki#u#run_code_snippet()
   command! -buffer WikiGraphFindBacklinks call wiki#graph#find_backlinks()
+  command! -buffer WikiGraphCheckLinks call wiki#graph#check_links()
   command! -buffer -count=99 WikiGraphIn  call wiki#graph#in(<count>)
   command! -buffer -count=99 WikiGraphOut call wiki#graph#out(<count>)
   command! -buffer WikiJournalIndex       call wiki#journal#make_index()
@@ -81,6 +82,7 @@ endfunction
 function! s:init_buffer_mappings() abort " {{{1
   nnoremap <silent><buffer> <plug>(wiki-code-run)             :WikiCodeRun<cr>
   nnoremap <silent><buffer> <plug>(wiki-graph-find-backlinks) :WikiGraphFindBacklinks<cr>
+  nnoremap <silent><buffer> <plug>(wiki-graph-check-links)    :WikiGraphCheckLinks<cr>
   nnoremap <silent><buffer> <plug>(wiki-graph-in)             :WikiGraphIn<cr>
   nnoremap <silent><buffer> <plug>(wiki-graph-out)            :WikiGraphOut<cr>
   nnoremap <silent><buffer> <plug>(wiki-journal-index)        :WikiJournalIndex<cr>
@@ -141,6 +143,7 @@ function! s:init_buffer_mappings() abort " {{{1
     let l:mappings = {
           \ '<plug>(wiki-code-run)' : '<leader>wc',
           \ '<plug>(wiki-graph-find-backlinks)' : '<leader>wb',
+          \ '<plug>(wiki-graph-check-links)' : '<leader>wlc',
           \ '<plug>(wiki-graph-in)' : '<leader>wg',
           \ '<plug>(wiki-graph-out)' : '<leader>wG',
           \ '<plug>(wiki-link-next)' : '<tab>',

--- a/autoload/wiki/graph.vim
+++ b/autoload/wiki/graph.vim
@@ -27,6 +27,40 @@ endfunction
 
 "}}}1
 
+function! wiki#graph#check_links() abort "{{{1
+  redraw
+  call wiki#log#info('Scanning wiki for broken links ... ')
+  sleep 25m
+
+  let l:broken_links = []
+
+  for l:file in globpath(b:wiki.root, '**/*.' . b:wiki.extension, 0, 1)
+    for l:link in filter(wiki#link#get_all(l:file),
+                \ 'get(v:val, ''scheme'', '''') ==# ''wiki''')
+        if !filereadable(l:link.path)
+            call add(l:broken_links, {
+                        \ 'filename' : l:file,
+                        \ 'text' : get(l:link, 'full'),
+                        \ 'anchor' : l:link.anchor,
+                        \ 'lnum' : l:link.lnum,
+                        \ 'col' : l:link.c1
+                        \})
+        endif
+    endfor
+  endfor
+
+  call wiki#log#info('Done!')
+
+  if empty(l:broken_links)
+    call wiki#log#info('No broken links exist')
+  else
+    call setloclist(0, l:broken_links, 'r')
+    lopen
+  endif
+endfunction
+
+"}}}1
+
 function! wiki#graph#out(...) abort " {{{1
   let l:max_level = a:0 > 0 ? a:1 : -1
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -575,6 +575,10 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *WikiGraphFindBacklinks*
   Find backlinks to current page.
 
+*<plug>(wiki-graph-check-links)*
+*WikiGraphCheckLinks*
+  Check for broken links.
+
 *<plug>(wiki-graph-in)*
 *<plug>(wiki-graph-out)*
 *WikiGraphIn*
@@ -829,6 +833,7 @@ information about the different modes.
    `n`     <leader>wx          |<plug>(wiki-reload)|              [GLOBAL]
    `n`     <leader>wc          |<plug>(wiki-code-run)|
    `n`     <leader>wb          |<plug>(wiki-graph-find-backlinks)|
+   `n`     <leader>wlc         |<plug>(wiki-graph-check-links)|
    `n`     <leader>wg          |<plug>(wiki-graph-in)|
    `n`     <leader>wG          |<plug>(wiki-graph-out)|
    `n`     <leader>wf          |<plug>(wiki-link-toggle)|


### PR DESCRIPTION
This feature runs a link search against all files in the wiki and opens a loclist with any wiki links that point to non-existing files. It's good to check for broken links after a migration or to check if any [red links](https://en.wikipedia.org/wiki/Wikipedia:Red_link) need to be updated.