### PR TITLE
create an extension point to let users override wiki page lookups

### DIFF
--- a/autoload/wiki/url/wiki.vim
+++ b/autoload/wiki/url/wiki.vim
@@ -20,6 +20,10 @@ function! wiki#url#wiki#parse(url) abort " {{{1
           \ . (l:anchors[0] =~# '/$' ? b:wiki.index_name : '')
   endif
 
+  if exists('*WikiSearchCommand')
+    let l:fname = WikiSearchCommand(g:wiki_root, l:fname)
+  endif
+
   " Extract the full path
   let l:url.path = l:fname[0] ==# '/'
         \ ? wiki#get_root() . l:fname

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -513,6 +513,13 @@ OPTIONS                                                   *wiki-config-options*
 
   Default: `'~/.local/zotero'`
 
+*WikiSearchCommand*
+  Funcref that takes wiki_root and filename and its return is the file to open
+  relative to the wiki_root. Define function in vimrc to override wiki page
+  lookup.
+  
+  Default: Undefined
+
 ------------------------------------------------------------------------------
 EVENTS                                                     *wiki-config-events*
 


### PR DESCRIPTION
## Intent
I wish to use vim to edit my notes but my main notes editor is <https://obsidian.md>. They allow fuzzy links like `[[Bunny]]` goes to a `Bunny.md` file that can exist anywhere in your tree. This is different from wiki.vim link behavior.

## How
Allow users to define a function named `WikiSearchCommand` that takes wiki_root and fname and outputs the transformed fname.

## Example usage
In my vimrc to get wiki.vim to support obsidian links:
```vim
function! WikiSearchCommand(wiki_root, fname)
  let files = systemlist(printf('pushd %s && fd -e "md" "%s" |tail -n1 && popd', a:wiki_root, a:fname))
  return get(files, 0, a:fname)
endfunction
```