### PR TITLE
Fix error in :WikiPageRename

### DIFF
--- a/autoload/wiki/page.vim
+++ b/autoload/wiki/page.vim
@@ -99,7 +99,7 @@ function! wiki#page#rename(newname, ...) abort "{{{1
   endif
 
   " Rename current file to l:newpath
-  let l:bufnr = bufnr()
+  let l:bufnr = bufnr('')
   try
     call wiki#log#info(
           \ printf('wiki: Renaming "%s" to "%s" ...',
@@ -115,7 +115,7 @@ function! wiki#page#rename(newname, ...) abort "{{{1
   " Open new file and remove old buffer
   execute 'silent edit' l:newpath
   execute 'silent bwipeout' l:bufnr
-  let l:bufnr = bufnr()
+  let l:bufnr = bufnr('')
 
   " Get list of open wiki buffers
   let l:bufs =


### PR DESCRIPTION
Trying to run `:WikiPageRename` asks the confirmation prompt and then the new name, but errors out after that: 
```

Error detected while processing function wiki#page#rename_ask[11]..wiki#page#rename:
line   64:
E119: Not enough arguments for function: bufnr
E15: Invalid expression: bufnr()
Press ENTER or type command to continue

```

I believe the problem is the empty call to `bufnr()` at lines 102 and 118 of ` autoload/wiki/page.vim `. Changing those to `bufnr('')` (like in scratch.vim) fixes the issue.