### PR TITLE
Support default 'date' on nvim 0.5 on OSX

### DIFF
--- a/autoload/wiki/date.vim
+++ b/autoload/wiki/date.vim
@@ -157,7 +157,7 @@ function! s:date(date, format) abort " {{{1
           \ . ' +"%s" -d "%s"', a:format, a:date))[0]
   else
     return systemlist(printf(s:cmd_date
-          \ . ' -j -f "%Y-%m-%d" "%s" +"%s"', a:date, a:format))[0]
+          \ . ' -j -f "%s" "%s" +"%s"', "%Y-%m-%d", a:date, a:format))[0]
   endif
 endfunction
 


### PR DESCRIPTION
Currently attempting to create a monthly summary by pressing `<leader>wm` leads to an error:
```
Error detected while processing function wiki#journal#freq[16]..wiki#date#format[1]..<SNR>92_date:
line    5:
E766: Insufficient arguments for printf()
```

This attempts to work around this by passing the format of the date  as a parameter to `printf` such that it is not attempting to interpret the date format as parameters to `printf` itself.