### PR TITLE
Add tag completion

### DIFF
--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -189,6 +189,41 @@ function! s:completer_zotero.complete(regex) dict abort " {{{2
 endfunction
 
 " }}}1
+" {{{1 Tags
+
+let s:completer_tags = {}
+
+function! s:completer_tags.findstart(line) dict abort " {{{2
+  " To avoid picking up the tag-end marker, extract the tags regex up to
+  " the \ze. If we can't find \ze, try the whole pattern.
+  let l:idx = stridx(g:wiki_tags_format_pattern, '\ze')
+  let l:pat = l:idx >= 0 ? strpart(g:wiki_tags_format_pattern, 0, l:idx) :
+      \ g:wiki_tags_format_pattern
+
+  "Match the last tag-start on the line
+  let l:start = 0
+  while 1
+    let l:mp = match(a:line, l:pat, l:start)
+    if l:mp > 0
+      let l:start = l:mp
+    else
+      break
+    endif
+  endwhile
+  return l:start > 0 ? l:start : -1
+
+endfunction
+
+function! s:completer_tags.complete(regex) dict abort " {{{2
+  let l:cands = keys(wiki#tags#get_all())
+  call filter(l:cands, 'stridx(v:val, a:regex) >= 0')
+  return map(sort(l:cands), "{
+        \ 'word': v:val,
+        \ 'kind': '[tag]'
+        \}")
+endfunction
+
+" }}}1
 
 "
 " Initialize module

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -492,6 +492,9 @@ OPTIONS                                                   *wiki-config-options*
   Default: >
     let g:wiki_tags_format_pattern = '\v%(^|\s):\zs[^: ]+\ze:'
 
+Tag autocomplete (|wiki-completion|) uses the pattern up to '\ze' to detect
+the start of an incomplete tag.
+
 *g:wiki_tags_scan_num_lines*
   A number of lines to read from the top of a page when scanning tags. To scan
   lines from the bottom, use a negative number, e.g. >
@@ -1146,9 +1149,10 @@ The `[<attrlist>]` will be recognized by wiki.vim as the link text.
 ==============================================================================
 COMPLETION                                                    *wiki-completion*
 
-This plugin provides an |omni-complete| function that completes internal link
-targets, including anchors.  This should work both for markdown and wiki
-style links (see |wiki-link|).
+This plugin provides an |omni-complete| function that completes tags and
+internal link targets, including anchors. Link completion should work both for
+markdown and wiki style links (see |wiki-link|). Tag completion uses
+|g:wiki_tags_format_pattern| to detect the start of an incomplete tag.
 
 ------------------------------------------------------------------------------
 AUTOCOMPLETE                                             *wiki-completion-auto*

--- a/test/wiki-basic/tagged.wiki
+++ b/test/wiki-basic/tagged.wiki
@@ -1,5 +1,5 @@
 # Intro
-:tagged:
+:tagged: :tagged2: :tagged3:
 
 This is a wiki.
 


### PR DESCRIPTION
It’s got a bit of a hack to avoid matching the end-of-tag marker when in `findstart` mode, but it seems to work in my basic testing. It does depend on `g:wiki_tags_format_pattern` having a `\ze`, but since that’s in the default pattern and is featured in the documentation examples, it seems likely to be fine.