### PR TITLE
fix: avoid toggling empty links, fix bug where some functions don't get called in template

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -77,6 +77,7 @@ endfunction
 " }}}1
 function! wiki#link#follow(...) abort "{{{1
   let l:link = wiki#link#get()
+  if empty(l:link) | return | endif
 
   try
     if has_key(l:link, 'follow')

--- a/autoload/wiki/template.vim
+++ b/autoload/wiki/template.vim
@@ -93,7 +93,7 @@ function! s:template_apply(t, ctx) abort " {{{1
     let l:lines = l:pre . l:value . l:post
 
     let [l:match, l:c1, l:c2] = matchstrpos(
-          \ l:lines, '{{[a-zA-Z#_0-9]\+\s*[^}]*}}', l:c2+1)
+          \ l:lines, '{{[a-zA-Z#_0-9]\+\s*[^}]*}}', l:c1)
   endwhile
 
   call append(0, split(l:lines, "\n"))


### PR DESCRIPTION
# Context

Hi @lervag, I really like your plugin so far! I made a few small changes locally and thought I'd share them:

* I noticed an annoying error if I accidentally hit Return in normal mode when my cursor was on a blank line.
* I had a problem with consecutive user-defined functions not being called in my wiki template

# Changes
* If there is no text under the cursor, exit early from `wiki#link#follow`(don't attempt to toggle an empty link)
* make the search for user-defined template functions less aggressive, since after the insertion of the result of the function call the length of the variable `l:lines` changes, and `l:c2` can extend beyond the beginning of the next curly-braces defining another custom function.