### PR TITLE
Tag renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Or use some other plugin manager:
 * [neobundle](https://github.com/Shougo/neobundle.vim)
 * [pathogen](https://github.com/tpope/vim-pathogen)
 
+Note that some features require a recent version of Vim (>= 8.1) or
+NeoVim (>= 0.5).
+
 ## Usage
 
 This outlines the basic steps to get started:

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -33,8 +33,6 @@ function! wiki#buffer#init() abort " {{{1
 endfunction
 
 " }}}1
-
-
 function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiGraphFindBacklinks call wiki#graph#find_backlinks()
   command! -buffer WikiGraphCheckLinks    call wiki#graph#check_links()
@@ -59,6 +57,7 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer          WikiTagReload call wiki#tags#reload()
   command! -buffer -nargs=* WikiTagList   call wiki#tags#list(<f-args>)
   command! -buffer -nargs=* WikiTagSearch call wiki#tags#search(<f-args>)
+  command! -buffer -nargs=+ -complete=custom,wiki#tags#get_tag_names WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
   command! -buffer          WikiFzfToc    call wiki#fzf#toc()
 
@@ -95,6 +94,7 @@ function! s:init_buffer_mappings() abort " {{{1
   nnoremap <silent><buffer> <plug>(wiki-tag-list)             :WikiTagList<cr>
   nnoremap <silent><buffer> <plug>(wiki-tag-reload)           :WikiTagReload<cr>
   nnoremap <silent><buffer> <plug>(wiki-tag-search)           :WikiTagSearch<cr>
+  nnoremap <silent><buffer> <plug>(wiki-tag-rename)           :WikiTagRename<cr>
 
   nnoremap <silent><buffer> <plug>(wiki-fzf-toc)              :WikiFzfToc<cr>
   inoremap <silent><buffer> <plug>(wiki-fzf-toc)              <esc>:WikiFzfToc<cr>
@@ -145,6 +145,7 @@ function! s:init_buffer_mappings() abort " {{{1
           \ '<plug>(wiki-tag-list)': '<leader>wsl',
           \ '<plug>(wiki-tag-reload)': '<leader>wsr',
           \ '<plug>(wiki-tag-search)': '<leader>wss',
+          \ '<plug>(wiki-tag-rename)': '<leader>wsn',
           \ 'x_<plug>(wiki-link-toggle-visual)': '<cr>',
           \ 'o_<plug>(wiki-au)': 'au',
           \ 'x_<plug>(wiki-au)': 'au',

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -33,6 +33,8 @@ function! wiki#buffer#init() abort " {{{1
 endfunction
 
 " }}}1
+
+
 function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiGraphFindBacklinks call wiki#graph#find_backlinks()
   command! -buffer WikiGraphCheckLinks    call wiki#graph#check_links()
@@ -57,7 +59,8 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer          WikiTagReload call wiki#tags#reload()
   command! -buffer -nargs=* WikiTagList   call wiki#tags#list(<f-args>)
   command! -buffer -nargs=* WikiTagSearch call wiki#tags#search(<f-args>)
-  command! -buffer -nargs=+ -complete=custom,wiki#tags#get_tag_names WikiTagRename call wiki#tags#rename_ask(<f-args>)
+  command! -buffer -nargs=+ -complete=custom,wiki#tags#get_tag_names
+				\ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
   command! -buffer          WikiFzfToc    call wiki#fzf#toc()
 

--- a/autoload/wiki/tags.vim
+++ b/autoload/wiki/tags.vim
@@ -85,7 +85,7 @@ function! wiki#tags#reload() abort " {{{1
 endfunction
 
 " }}}1
-function! wiki#tags#rename(old_tag, new_tag='', rename_to_existing=0) abort " {{{1
+function! wiki#tags#rename(old_tag, new_tag='', rename_to_existing=v:false) abort " {{{1
   if a:new_tag ==# ''
     call wiki#tags#rename_ask(a:old_tag)
   else

--- a/autoload/wiki/tags.vim
+++ b/autoload/wiki/tags.vim
@@ -9,8 +9,17 @@ function! wiki#tags#get_all() abort " {{{1
 endfunction
 
 " }}}1
-function! wiki#tags#get_tag_names(...) abort " {{{1
-  return join(map(keys(wiki#tags#get_all()), 'escape(v:val, " ")'), "\n")
+function! wiki#tags#get_tag_names() abort " {{{1
+  return keys(wiki#tags#get_all())
+endfunction
+
+" }}}1
+function! wiki#tags#complete_tag_names(...) abort " {{{1
+  " Returns tag names in newline separated string suitable for completion with
+  " the "custom" argument, see ":help :command-completion-custom". We could
+  " also have used "customlist", but with "custom", filtering is performed
+  " implicitly and may be more efficient (cf. documentation).
+  return join(map(wiki#tags#get_tag_names(), 'escape(v:val, " ")'), "\n")
 endfunction
 
 " }}}1
@@ -86,9 +95,10 @@ endfunction
 
 " }}}1
 function! wiki#tags#rename_ask(old_tag='', new_tag='', ...) abort " {{{1
-  let l:old_tag = a:old_tag ==# '' ?
-        \ input('Enter tag to rename (wihtout delimiters): ', '', 'custom,wiki#tags#get_tag_names') :
-        \ a:old_tag
+  let l:old_tag = a:old_tag ==# ''
+        \ ? input('Enter tag to rename (wihtout delimiters): ',
+                  '', 'custom,wiki#tags#get_tag_names')
+        \ : a:old_tag
   if l:old_tag ==# '' | return | endif
 
   if input('Rename "' . l:old_tag . '"'
@@ -110,6 +120,8 @@ function! wiki#tags#rename_ask(old_tag='', new_tag='', ...) abort " {{{1
 endfunction
 
 " }}}1
+
+
 function! s:search(cfg) abort " {{{1
   call s:tags.gather()
   let l:tags = get(s:tags.collection, a:cfg.tag, [])
@@ -368,7 +380,7 @@ function! s:tags.add(tag, ...) abort dict " {{{1
 endfunction
 
 " }}}1
-function! s:tags.rename(old_tag, new_tag, rename_to_existing=0) abort dict " {{{1
+function! s:tags.rename(old_tag, new_tag, rename_to_existing=v:false) abort dict " {{{1
   redraw!
   if !has_key(self.collection, a:old_tag)
     call wiki#log#info('Old tag name "' . a:old_tag . '" not found in cache; reloading tags.')
@@ -429,7 +441,6 @@ function! s:tags.rename(old_tag, new_tag, rename_to_existing=0) abort dict " {{{
   execute 'buffer' l:bufnr
 
   call wiki#log#info(printf('Renamed tags in %d files', l:num_files))
-
 endfunction
 
 " }}}1

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -682,6 +682,12 @@ OPTIONS                                                   *wiki-config-options*
       A function (|FuncRef|) that takes a single argument, the current line.
       It should return a list of the tags in the given line.
 
+    make~
+      A function (|FuncRef|) that takes two arguments: a list of tags, and the
+      current line. It should return a new line with the list of tags
+      formatted appropriately. This new line will replace the current line.
+      This function is used by |WikiTagRename|.
+
     re_findstart~
       `OPTIONAL`
       A regular expression (|String|) that should match the start of the
@@ -694,7 +700,8 @@ OPTIONS                                                   *wiki-config-options*
     let g:wiki_tag_parsers = [
           \ g:wiki#tags#default_parser,
           \ { 'match': {x -> x =~# '^tags: '},
-          \   'parse': {x -> split(matchstr(x, '^tags:\zs.*'), '[ ,]\+')}}
+          \   'parse': {x -> split(matchstr(x, '^tags:\zs.*'), '[ ,]\+')},
+          \   'make':  {t,x -> 'tags: ' . empty(t) ? '' : join(t, ', ')}}
           \]
 <
   See |g:wiki#tags#default_parser| for details on the default tag parser.
@@ -1061,6 +1068,12 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
       * `scratch`   Add results to a scratch buffer
       * `cursor`    Insert result below cursor
 
+*<plug>(wiki-tag-rename)*
+*WikiTagRename*  [old_tag] [new_tag]
+  Rename `old_tag` to `new_tag` in all pages. If zero or one arguments are
+  supplied, the command asks for input. This command uses the `make` function
+  of |g:wiki_tag_parsers|.
+
 *CtrlPWiki*
   Open |CtrlP| in find file mode for wiki files in current wiki or in the main
   wiki defined by |g:wiki_root|.
@@ -1423,6 +1436,7 @@ Related commands:
 - |WikiTagList|
 - |WikiTagReload|
 - |WikiTagSearch|
+- |WikiTagRename|
 - |WikiFzfTags|
 
 Related settings:
@@ -1462,13 +1476,18 @@ for convenience: >
     return l:tags
   endfunction
 
-One may customize the default parser by adjusting the `re_match` and
-`re_findstart` strings. E.g., to instead recognize hashed tags like `#tag1`
-and `#my-other-tag`, one could add the following in ones vimrc: >
+  function! g:wiki#tags#default_parser.make(taglist, curline='') dict abort
+    return empty(a:taglist) ? '' : join(map(a:taglist, '":" . v:val . ":"'))
+  endfunction
+
+One may customize the default parser by adjusting `re_match`, 
+`re_findstart`, and `make`. E.g., to instead recognize hashed tags like `#tag1`
+and `#my-other-tag`, one could add the following in one's vimrc: >
 
   let s:tag_parser = deepcopy(g:wiki#tags#default_parser)
   let s:tag_parser.re_match = '\v%(^|\s)#\zs[^# ]+'
   let s:tag_parser.re_findstart = '\v%(^|\s)#\zs[^# ]+'
+  let s:tag_parser.make = {t,l -> empty(t) ? '' : join(map(t, '"#" . v:val))}
 
   let g:wiki_tag_parsers = [s:tag_parser]
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -90,9 +90,11 @@ Note: |wiki.vim| is `not` a filetype plugin. It is designed so that it may be us
 REQUIREMENTS                                          *wiki-intro-requirements*
 
 This plugin is mainly developed on and for Linux. Some or most of the features
-should still work on Windows and OSX, but currently there are no guaranties.
+should still work on Windows and OSX, but currently there are no guarantees.
 On Windows, it is assumed that users enable 'shellslash' to avoid issues with
 backslashes versus forward slashes.
+
+Some features require a recent version of Vim (>= 8.1) or NeoVim (>= 0.5).
 
 The following is a list of external tools that are used for some of the
 features:

--- a/test/test-tags/test-custom-yaml.vim
+++ b/test/test-tags/test-custom-yaml.vim
@@ -8,12 +8,18 @@ let g:wiki_link_extension = '.md'
 let g:wiki_tag_parsers = [
       \ g:wiki#tags#default_parser,
       \ { 'match': {x -> x =~# '^tags: '},
-      \   'parse': {x -> split(matchstr(x, '^tags:\zs.*'), '[ ,]\+')}}
+      \   'parse': {x -> split(matchstr(x, '^tags:\zs.*'), '[ ,]\+')},
+			\   'make': {t,l -> empty(t) ? '' : 'tags: ' . join(t, ', ')}}
       \]
 
 silent edit ../wiki-markdown/index.md
 
 let s:tags = wiki#tags#get_all()
 call assert_equal(['drink', 'good', 'life', 'work'], sort(keys(s:tags)))
+
+call wiki#tags#rename('drink', 'coffee', 1)
+call wiki#tags#rename('work', 'coffee', 1)
+call wiki#tags#rename('life', 'good', 1)
+call assert_equal('tags: coffee, good', readfile('../wiki-markdown/yaml-tags.md')[2])
 
 call wiki#test#finished()

--- a/test/test-tags/test-defaults.vim
+++ b/test/test-tags/test-defaults.vim
@@ -6,8 +6,17 @@ let g:wiki_cache_persistent = 0
 silent edit ../wiki-basic/index.wiki
 
 let s:tags = wiki#tags#get_all()
-call assert_equal(5, len(s:tags))
+call assert_equal(8, len(s:tags))
 call assert_equal(1, len(s:tags.tag1))
 call assert_equal(2, len(s:tags.marked))
+
+"Original line in tagged.wiki is:
+":tag_six: :tag3: :tag4: :tag5: :tag6:
+call wiki#tags#rename('tag4', 'tag_four', 1)  "Basic renaming
+call wiki#tags#rename('tag5', 'tag_four', 1)  "Rename to an existing tag
+call wiki#tags#rename('tag6', 'tag_six', 1)   "Rename to an existing tag, keeping original ordering
+call assert_equal(
+          \ ':tag_six: :tag3: :tag_four:',
+          \ readfile('../wiki-basic/tagged.wiki')[1])
 
 call wiki#test#finished()

--- a/test/wiki-basic/tagged.wiki
+++ b/test/wiki-basic/tagged.wiki
@@ -1,5 +1,5 @@
 # Intro
-:tag3: :tag4:
+:tag_six: :tag3: :tag4: :tag5: :tag6:
 
 This is a wiki.
 


### PR DESCRIPTION
This PR adds functionality to rename tags. Some highlights:

`tags.vim`:

- `wiki#tags#rename(old_tag, new_tag='', rename_to_existing=0)`<br>The main renaming function. The `rename_to_existing` parameter forces a tag to be renamed even if the new name already exists (implemented primarily for non-interactive testing).
- `wiki#tags#rename_ask(old_tag='', new_tag='', ...)`<br>The user-facing rename function, called by the `WikiTagRename` command. Prompts for one or both parameters.
- `wiki#tags#get_tag_names(...)`<br>Returns a list of tag names from the cache. Used for completion by `WikiTagRename`.
- `g:wiki#tags#default_parser.make(taglist, curline='')`<br>Required to construct a new buffer line containing the updated tag name.

`buffer.vim`:

- Command `WikiTagRename`
- Default mapping: `<leader>wsn` → `<plug>(wiki-tag-rename)`

Tests:

- Added test cases for renaming tags to `test-tags/test-defaults.vim` and `test-tags/test-custom-yaml.vim`

There is some overlap in functionality between `tags.vim:394-407,420-424` and `page.vim:118-132,137-141`, but I wasn’t sure if it was worth pulling out into a third file.