### PR TITLE
Restore explicit check for iOS

### DIFF
--- a/autoload/wiki/u.vim
+++ b/autoload/wiki/u.vim
@@ -72,7 +72,7 @@ function! wiki#u#get_os() abort " {{{1
   if has('win32') || has('win32unix')
     return 'win'
   elseif has('unix')
-    if has('mac') || wiki#jobs#cached('uname')[0] =~# 'Darwin'
+    if has('mac') || has('ios') || wiki#jobs#cached('uname')[0] =~# 'Darwin'
       return 'mac'
     else
       return 'linux'


### PR DESCRIPTION
#168 fixed terrychou/iVim#205 due to system calls not working during startup; 1459952e92b58b7682c7513338ef47febca5495e regresses back to this bug. This restores the explicit check for iOS to avoid the problem.