### PR TITLE
Add option for case-insensitive omnicomplete

### DIFF
--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -29,8 +29,7 @@ function! wiki#complete#link(lead, line, pos) abort " {{{1
   let l:candidates = s:completer_wikilink.complete(l:input)
   call map(l:candidates, 'v:val.word')
   if !s:completer_wikilink.is_anchor
-    return filter(l:candidates, {_,x -> match(x,
-          \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . l:input) == 0})
+    return s:filter_candidates(l:candidates, '^' . l:input)
   endif
 
   return map(l:candidates, 'l:base . v:val')
@@ -100,13 +99,10 @@ function! s:completer_wikilink.complete_anchor(regex) dict abort " {{{2
   let l:length = strlen(l:base)
 
   let l:anchors = wiki#toc#gather_anchors(l:url)
-  call filter(l:anchors, {_,x -> match(x,
-        \ (g:wiki_completion_case_sensitive ? '\C' : '\c')
-        \ . '^' . wiki#u#escape(l:base) . '[^#]*$') >= 0})
+  call s:filter_candidates(l:anchors, '^' . wiki#u#escape(l:base) . '[^#]*$')
   call map(l:anchors, 'strpart(v:val, l:length)')
   if !empty(a:regex)
-    call filter(l:anchors, {_,x -> match(x,
-        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
+    call s:filter_candidates(l:anchors, a:regex)
   endif
 
   return l:anchors
@@ -126,8 +122,7 @@ function! s:completer_wikilink.complete_page(regex) dict abort " {{{2
         \ empty(b:wiki.link_extension)
         \ ? 'l:pre . fnamemodify(v:val, '':r'')'
         \ : 'l:pre . v:val')
-  call filter(l:cands, {_,x -> match(x,
-        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
+  call s:filter_candidates(l:cands, a:regex)
 
   call sort(l:cands)
 
@@ -212,14 +207,25 @@ endfunction
 
 function! s:completer_tags.complete(regex) dict abort " {{{2
   let l:candidates = keys(wiki#tags#get_all())
-  call filter(l:candidates, {_, x -> match(x,
-        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
+  call s:filter_candidates(l:candidates, a:regex)
   return map(sort(l:candidates), {_, x -> {
         \ 'word': x,
         \ 'kind': '[tag]'
         \}})
 endfunction
 
+" }}}1
+
+"
+" Utility
+"
+function s:filter_candidates(cands, regex) " {{{1
+  " Filter list a:cands for a match with a:regex anywhere in items, with
+  " case-sensitivity depending on the value of g:wiki_completion_case_sensitive
+  call filter(a:cands, {_,x -> match(x,
+        \ (g:wiki_completion_case_sensitive ? '\C' : '\c')
+        \ . a:regex) >= 0})
+endfunction
 " }}}1
 
 "

--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -29,7 +29,8 @@ function! wiki#complete#link(lead, line, pos) abort " {{{1
   let l:candidates = s:completer_wikilink.complete(l:input)
   call map(l:candidates, 'v:val.word')
   if !s:completer_wikilink.is_anchor
-    return filter(l:candidates, 'stridx(v:val, l:input) == 0')
+    return filter(l:candidates, {_,x -> match(x,
+          \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . l:input) == 0})
   endif
 
   return map(l:candidates, 'l:base . v:val')
@@ -99,10 +100,13 @@ function! s:completer_wikilink.complete_anchor(regex) dict abort " {{{2
   let l:length = strlen(l:base)
 
   let l:anchors = wiki#toc#gather_anchors(l:url)
-  call filter(l:anchors, 'v:val =~# ''^'' . wiki#u#escape(l:base) . ''[^#]*$''')
+  call filter(l:anchors, {_,x -> match(x,
+        \ (g:wiki_completion_case_sensitive ? '\C' : '\c')
+        \ . '^' . wiki#u#escape(l:base) . '[^#]*$') >= 0})
   call map(l:anchors, 'strpart(v:val, l:length)')
   if !empty(a:regex)
-    call filter(l:anchors, 'v:val =~# ''' . a:regex . '''')
+    call filter(l:anchors, {_,x -> match(x,
+        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
   endif
 
   return l:anchors
@@ -122,7 +126,8 @@ function! s:completer_wikilink.complete_page(regex) dict abort " {{{2
         \ empty(b:wiki.link_extension)
         \ ? 'l:pre . fnamemodify(v:val, '':r'')'
         \ : 'l:pre . v:val')
-  call filter(l:cands, 'stridx(v:val, a:regex) >= 0')
+  call filter(l:cands, {_,x -> match(x,
+        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
 
   call sort(l:cands)
 
@@ -207,7 +212,8 @@ endfunction
 
 function! s:completer_tags.complete(regex) dict abort " {{{2
   let l:candidates = keys(wiki#tags#get_all())
-  call filter(l:candidates, {_, x -> stridx(x, a:regex) >= 0})
+  call filter(l:candidates, {_, x -> match(x,
+        \ (g:wiki_completion_case_sensitive ? '\C' : '\c') . a:regex) >= 0})
   return map(sort(l:candidates), {_, x -> {
         \ 'word': x,
         \ 'kind': '[tag]'

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -340,6 +340,12 @@ OPTIONS                                                   *wiki-config-options*
 
   Default value: 1
 
+*g:wiki_completion_case_sensitive*
+  Specify whether to use case-sensitive matching for omnicompletion of links
+  and tags.
+
+  Default value: 1
+
 *g:wiki_date_exe*
   Specify the executable for `date`, which is used "behind the scenes" to
   manipulate and calculate dates for the journal features.

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -15,6 +15,7 @@ call wiki#init#option('wiki_cache_root',
       \ : (empty($XDG_CACHE_HOME)
       \    ? $HOME . '/.cache'
       \    : $XDG_CACHE_HOME) . '/wiki.vim')
+call wiki#init#option('wiki_completion_case_sensitive', 1)
 call wiki#init#option('wiki_export', {
       \ 'args' : '',
       \ 'from_format' : 'markdown',

--- a/test/test-complete/test-tags.vim
+++ b/test/test-complete/test-tags.vim
@@ -7,6 +7,12 @@ silent edit ../wiki-basic/index.wiki
 
 let s:candidates = wiki#test#completion(':t', 'tag')
 call assert_equal(7, len(s:candidates))
+let s:candidates = wiki#test#completion(':T', 'Tag')
+call assert_equal(0, len(s:candidates))
+let g:wiki_completion_case_sensitive = 0
+let s:candidates = wiki#test#completion(':T', 'Tag')
+call assert_equal(7, len(s:candidates))
+let g:wiki_completion_case_sensitive = 1
 
 let s:candidates = wiki#test#completion(':m', 'mar')
 call assert_equal(1, len(s:candidates))

--- a/test/test-complete/test-wikilinks.vim
+++ b/test/test-complete/test-wikilinks.vim
@@ -12,10 +12,23 @@ let s:candidates = wiki#test#completion('[[/', 'in')
 call assert_equal(7, len(s:candidates))
 call assert_equal('/', s:candidates[0].word[0])
 
+let s:candidates = wiki#test#completion('[[', 'new')
+call assert_equal(0, len(s:candidates))
+let g:wiki_completion_case_sensitive = 0
+let s:candidates = wiki#test#completion('[[', 'new')
+call assert_equal(1, len(s:candidates))
+let g:wiki_completion_case_sensitive = 1
+
 silent edit ../wiki-basic/ToC-reference.wiki
 
 let s:candidates = wiki#test#completion('[[#2 Next chapter#', '')
 call assert_equal(3, len(s:candidates))
+let s:candidates = wiki#test#completion('[[#2 n', '2 n')
+call assert_equal(0, len(s:candidates))
+let g:wiki_completion_case_sensitive = 0
+let s:candidates = wiki#test#completion('[[#2 n', '2 n')
+call assert_equal(2, len(s:candidates))
+let g:wiki_completion_case_sensitive = 1
 
 " Profiling on @lervag's personal wiki
 " silent edit ~/.local/wiki/index.wiki

--- a/test/wiki-basic/ToC-reference.wiki
+++ b/test/wiki-basic/ToC-reference.wiki
@@ -29,3 +29,5 @@
 ## 1.2 Level 2
 
 ## 1.3 Level 2
+
+# 2 Nothing here

--- a/test/wiki-basic/ToC.wiki
+++ b/test/wiki-basic/ToC.wiki
@@ -26,3 +26,5 @@
 ## 1.2 Level 2
 
 ## 1.3 Level 2
+
+# 2 Nothing here


### PR DESCRIPTION
My wiki files all have the first letter capitalized, which makes case-sensitive searching inconvenient. I added an option `g:wiki_completion_case_sensitive` to optionally do case-insensitive searching.