### PR TITLE
Use wiki_index_name global to set a custom index page name.

### DIFF
--- a/autoload/wiki.vim
+++ b/autoload/wiki.vim
@@ -54,7 +54,8 @@ endfunction
 " }}}1
 
 function! wiki#goto_index() abort " {{{1
-  call wiki#url#parse('wiki:/index').follow()
+  let l:index_url = printf('wiki:/%s', g:wiki_index_name)
+  call wiki#url#parse(l:index_url).follow()
 endfunction
 
 " }}}1

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -426,6 +426,12 @@ OPTIONS                                                   *wiki-config-options*
 
   Default: 1
 
+g:wiki_index_name
+  A string with the index page name for the wiki. The value should not include
+  the file extension.
+
+  Default: 'index'
+
 *g:wiki_journal*
   A dictionary for configuring the journal/diary feature. Available options
   are:


### PR DESCRIPTION
Love the work you have put into Wiki.vim.

This is a small change to configure the name of the index page, by using the wiki_index_name variable in the goto_index function.

Thanks for considering it.