### PR TITLE
Remove unneeded bolditalic and italicbold regexes

### DIFF
--- a/autoload/wiki/rx.vim
+++ b/autoload/wiki/rx.vim
@@ -31,10 +31,6 @@ let wiki#rx#bold = wiki#rx#surrounded(
       \ '[^*`[:space:]]\%([^*`]*[^*`[:space:]]\)\?', '*')
 let wiki#rx#italic = wiki#rx#surrounded(
       \ '[^_`[:space:]]\%([^_`]*[^_`[:space:]]\)\?', '_')
-let wiki#rx#bolditalic = wiki#rx#surrounded(
-      \ '[^*_`[:space:]]\%([^*_`]*[^*_`[:space:]]\)\?', '*_')
-let wiki#rx#italicbold = wiki#rx#surrounded(
-      \ '[^_*`[:space:]]\%([^_*`]*[^_*`[:space:]]\)\?', '_*')
 let wiki#rx#date = '\d\d\d\d-\d\d-\d\d'
 let wiki#rx#url = '\<\l\+:\%(\/\/\)\?[^ \t()\[\]|]\+'
 let wiki#rx#reftext = '[^\\\[\]]\{-}'


### PR DESCRIPTION
Due to improved wiki-ft syntax matching; see lervag/wiki-ft.vim#8 .