### PR TITLE
Added command to follow link in new tab

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -86,6 +86,7 @@ function! s:init_buffer_mappings() abort " {{{1
   nnoremap <silent><buffer> <plug>(wiki-link-extract-header)  :WikiLinkExtractHeader<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-follow)          :WikiLinkFollow<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-follow-split)    :WikiLinkFollowSplit<cr>
+  nnoremap <silent><buffer> <plug>(wiki-link-follow-tab)      :WikiLinkFollowTab<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-prev)            :WikiLinkPrev<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-return)          :WikiLinkReturn<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-toggle)          :WikiLinkToggle<cr>
@@ -137,6 +138,7 @@ function! s:init_buffer_mappings() abort " {{{1
           \ '<plug>(wiki-link-extract-header)': '<leader>wlh',
           \ '<plug>(wiki-link-follow)': '<cr>',
           \ '<plug>(wiki-link-follow-split)': '<c-w><cr>',
+          \ '<plug>(wiki-link-follow-tab)': '<c-w>u',
           \ '<plug>(wiki-link-return)': '<bs>',
           \ '<plug>(wiki-link-toggle)': '<leader>wf',
           \ '<plug>(wiki-link-toggle-operator)': 'gl',

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -46,6 +46,7 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiLinkExtractHeader  call wiki#link#set_text_from_header()
   command! -buffer WikiLinkFollow         call wiki#link#follow()
   command! -buffer WikiLinkFollowSplit    call wiki#link#follow('vsplit')
+  command! -buffer WikiLinkFollowTab      call wiki#link#follow('tabe')
   command! -buffer WikiLinkPrev           call wiki#nav#prev_link()
   command! -buffer WikiLinkReturn         call wiki#nav#return()
   command! -buffer WikiLinkToggle         call wiki#link#toggle_current()

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -943,6 +943,10 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *WikiLinkFollowSplit*
   Similar to |WikiLinkfollow|, except wiki links are followed in a |vsplit|.
 
+*<plug>(wiki-link-follow-tab)*
+*WikiLinkFollowTab*
+  Similar to |WikiLinkfollow|, except wiki links are followed in a |tabedit|.
+
 *<plug>(wiki-link-return)*
 *WikiLinkReturn*
   Go back to previous page, i.e. undo the last follow operation.
@@ -1183,6 +1187,7 @@ information about the different modes.
   `n`     <tab>               |<plug>(wiki-link-next)|
   `n`     <cr>                |<plug>(wiki-link-follow)|
   `n`     <c-w><cr>           |<plug>(wiki-link-follow-split)|
+  `n`     <c-w>u              |<plug>(wiki-link-follow-tab)|
   `n`     <s-tab>             |<plug>(wiki-link-prev)|
   `n`     <bs>                |<plug>(wiki-link-return)|
   `n`     gl                  |<plug>(wiki-link-toggle-operator)|


### PR DESCRIPTION
Created command WikiLinkFollowTab to open the link under cursor in a new tab. No default keybinding is associated. This behavior will be familiar to those used to navigating Zettelkästen via GUI applications, and there is no obvious drawback to including it in the project.