### PR TITLE
Make goto_index obey wiki_link_extension

### DIFF
--- a/autoload/wiki.vim
+++ b/autoload/wiki.vim
@@ -54,7 +54,7 @@ endfunction
 " }}}1
 
 function! wiki#goto_index() abort " {{{1
-  let l:index_url = printf('wiki:/%s', g:wiki_index_name)
+  let l:index_url = printf('wiki:/%s', g:wiki_index_name . g:wiki_link_extension)
   call wiki#url#parse(l:index_url).follow()
 endfunction
 


### PR DESCRIPTION
I experience the following issue, which I believe to have fixed:
I have `let wiki_link_extension='.wiki'`. When I have a markdown file open (from random editing) and want to open the wiki index (pressing <leader>ww), I'm brought to `index.**md**` instead of `index.wiki` (both files happen to be in my root folder).  

The following fix adds g:wiki_link_extension to g:wiki_index_name.

Thanks for a great plugin btw!