### PR TITLE
Allow %Y to appear multiple times in a journal entry name

### DIFF
--- a/autoload/wiki/date.vim
+++ b/autoload/wiki/date.vim
@@ -96,7 +96,7 @@ endfunction
 
 function! wiki#date#format_to_regex(format) abort " {{{1
   let l:regex = substitute(a:format, '\C%[ymdVU]', '\\d\\d', 'g')
-  return substitute(l:regex, '\C%Y', '\\d\\d\\d\\d', '')
+  return substitute(l:regex, '\C%Y', '\\d\\d\\d\\d', 'g')
 endfunction
 
 " }}}1


### PR DESCRIPTION
Only one byte!
I wanted journal entries to be in %Y/%m/%Y-%m-%d format so that if I ever flattened the hierarchy, I wouldn't have to rename any of the files. This broke many commands for the journal because I used %Y twice.