### PR TITLE
Adding support for neovim `vim.ui.select`

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -74,6 +74,7 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer -nargs=+ -complete=custom,wiki#tags#get_tag_names
         \ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
+  command! -buffer          WikiToc    call luaeval("require('wiki').toc()")
   command! -buffer          WikiFzfToc    call wiki#fzf#toc()
   command! -buffer -nargs=1 WikiClearCache call wiki#cache#clear(<q-args>)
 

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -63,8 +63,8 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiPageDelete         call wiki#page#delete()
   command! -buffer WikiPageRename         call wiki#page#rename()
   command! -buffer WikiPageRenameSection  call wiki#page#rename_section()
-  command! -buffer WikiGenerateToc        call wiki#toc#create(0)
-  command! -buffer WikiGenerateToc        call wiki#toc#create(1)
+  command! -buffer WikiTocGenerate        call wiki#toc#create(0)
+  command! -buffer WikiTocGenerateLocal   call wiki#toc#create(1)
   command! -buffer -range=% -nargs=* WikiExport
         \ call wiki#page#export(<line1>, <line2>, <f-args>)
 
@@ -75,9 +75,9 @@ function! s:init_buffer_commands() abort " {{{1
         \ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
   if has('nvim')
-    command! -buffer WikiToc     call luaeval("require('wiki').toc()")
+    command! -buffer WikiToc lua require('wiki').toc()
   else
-    command! -buffer WikiToc  call wiki#fzf#toc()
+    command! -buffer WikiToc call wiki#fzf#toc()
   endif
   command! -buffer -nargs=1 WikiClearCache call wiki#cache#clear(<q-args>)
 
@@ -168,8 +168,8 @@ function! s:init_buffer_mappings() abort " {{{1
           \ '<plug>(wiki-page-delete)': '<leader>wd',
           \ '<plug>(wiki-page-rename)': '<leader>wr',
           \ '<plug>(wiki-page-rename-section)': '<f2>',
-          \ '<plug>(wiki-generate-toc)': '<leader>wt',
-          \ '<plug>(wiki-genrate-toc-local)': '<leader>wT',
+          \ '<plug>(wiki-toc-generate)': '<leader>wt',
+          \ '<plug>(wiki-toc-generate-local)': '<leader>wT',
           \ '<plug>(wiki-export)': '<leader>wp',
           \ 'x_<plug>(wiki-export)': '<leader>wp',
           \ '<plug>(wiki-tag-list)': '<leader>wsl',

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -63,8 +63,8 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer WikiPageDelete         call wiki#page#delete()
   command! -buffer WikiPageRename         call wiki#page#rename()
   command! -buffer WikiPageRenameSection  call wiki#page#rename_section()
-  command! -buffer WikiPageToc            call wiki#toc#create(0)
-  command! -buffer WikiPageTocLocal       call wiki#toc#create(1)
+  command! -buffer WikiGenerateToc        call wiki#toc#create(0)
+  command! -buffer WikiGenerateToc        call wiki#toc#create(1)
   command! -buffer -range=% -nargs=* WikiExport
         \ call wiki#page#export(<line1>, <line2>, <f-args>)
 
@@ -74,8 +74,11 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer -nargs=+ -complete=custom,wiki#tags#get_tag_names
         \ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
-  command! -buffer          WikiToc    call luaeval("require('wiki').toc()")
-  command! -buffer          WikiFzfToc    call wiki#fzf#toc()
+  if has('nvim')
+    command! -buffer WikiToc     call luaeval("require('wiki').toc()")
+  else
+    command! -buffer WikiToc  call wiki#fzf#toc()
+  endif
   command! -buffer -nargs=1 WikiClearCache call wiki#cache#clear(<q-args>)
 
   if b:wiki.in_journal
@@ -118,8 +121,8 @@ function! s:init_buffer_mappings() abort " {{{1
   nnoremap <silent><buffer> <plug>(wiki-tag-search)           :WikiTagSearch<cr>
   nnoremap <silent><buffer> <plug>(wiki-tag-rename)           :WikiTagRename<cr>
 
-  nnoremap <silent><buffer> <plug>(wiki-fzf-toc)              :WikiFzfToc<cr>
-  inoremap <silent><buffer> <plug>(wiki-fzf-toc)              <esc>:WikiFzfToc<cr>
+  nnoremap <silent><buffer> <plug>(wiki-toc)                  :WikiToc<cr>
+  inoremap <silent><buffer> <plug>(wiki-toc)                  <esc>:WikiToc<cr>
 
   xnoremap <silent><buffer> <plug>(wiki-link-toggle-visual)   :<c-u>call wiki#link#toggle_visual()<cr>
   nnoremap <silent><buffer> <plug>(wiki-link-toggle-operator) :set opfunc=wiki#link#toggle_operator<cr>g@
@@ -165,8 +168,8 @@ function! s:init_buffer_mappings() abort " {{{1
           \ '<plug>(wiki-page-delete)': '<leader>wd',
           \ '<plug>(wiki-page-rename)': '<leader>wr',
           \ '<plug>(wiki-page-rename-section)': '<f2>',
-          \ '<plug>(wiki-page-toc)': '<leader>wt',
-          \ '<plug>(wiki-page-toc-local)': '<leader>wT',
+          \ '<plug>(wiki-generate-toc)': '<leader>wt',
+          \ '<plug>(wiki-genrate-toc-local)': '<leader>wT',
           \ '<plug>(wiki-export)': '<leader>wp',
           \ 'x_<plug>(wiki-export)': '<leader>wp',
           \ '<plug>(wiki-tag-list)': '<leader>wsl',

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -158,7 +158,7 @@ FEATURES                                                  *wiki-intro-features*
 * Utility functionality
   * |WikiExport| command for exporting to e.g. `pdf` with `pandoc`
 * Third-party support
-  * |fzf|: |WikiFzfPages|, |WikiFzfToc|, and |WikiFzfTags| commands
+  * |fzf|: |WikiPages|, |WikiToc|, and |WikiTags| commands
     (https://github.com/junegunn/fzf.vim)
 
 ------------------------------------------------------------------------------
@@ -184,7 +184,7 @@ Executive summary ~
 * Speed is key - make sure you have a fast workflow:
   * Use a keyboard shortcut in your desktop/window manager to open Vim/neovim
     with the wiki index (e.g. <alt-n>).
-  * Use something like |:WikiFzfPages| and `ripgrep` (with e.g.
+  * Use something like |:WikiPages| and `ripgrep` (with e.g.
     `ctrlsf.vim` [2]) for searching.
 * Write short pages and use links between related pages.
 * Don't obsess about the wiki structure.
@@ -211,7 +211,7 @@ previously also used Dropbox.
 
 Needless to say, it is important to be able to find relevant notes fast.
 I have a global Vim mapping `<leader>ow` to open a page search interface.
-I previously used |:WikiFzfPages|, which works very well! Today, though, I use
+I previously used |:WikiPages|, which works very well! Today, though, I use
 Telescope [4] with a personal function to list wiki files [5]. It usually
 takes no more than a couple of seconds from the moment I think of something
 until I have opened the relevant note. A key here is to use simple names for
@@ -523,7 +523,7 @@ OPTIONS                                                   *wiki-config-options*
     endfunction
 
 *g:wiki_fzf_pages_force_create_key*
-  Key combination that, when pressed while searching with |WikiFzfPages|, will
+  Key combination that, when pressed while searching with |WikiPages|, will
   create a new page with the name of the query. The value must be a string
   recognized by fzf's `--expect` argument; see fzf's manual page for a list of
   available keys.
@@ -531,7 +531,7 @@ OPTIONS                                                   *wiki-config-options*
   Default: `'alt-enter'`
 
 *g:wiki_fzf_pages_opts*
-  A string with additional user options for |WikiFzfPages|. This can be used
+  A string with additional user options for |WikiPages|. This can be used
   e.g. to add a previewer. Users should be aware that the page candidates are
   "prettified" with the `--with-nth=1` and `-d` options for fzf, so to obtain
   the page path in a previewer option one must use the field index expression `1`.
@@ -542,7 +542,7 @@ OPTIONS                                                   *wiki-config-options*
   Default: `''`
 
 *g:wiki_fzf_tags_opts*
-  A string with additional user options for |WikiFzfTags|. This can be used
+  A string with additional user options for |WikiTags|. This can be used
   e.g. to add a previewer. Users should be aware that the page candidates are
   "prettified" with the `-d` option for fzf, so to obtain the page path in a
   previewer option one must use the field index expression `2..`.
@@ -1318,12 +1318,12 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *WikiPageRename*
   Rename wiki page (will update all links to the page).
 
-*<plug>(wiki-page-toc)*
-*WikiPageToc*
+*<plug>(wiki-generate-toc)*
+*WikiGenerateToc*
   Create/Update table of contents.
 
-*<plug>(wiki-page-toc-local)*
-*WikiPageTocLocal*
+*<plug>(wiki-generate-toc-local)*
+*WikiGenerateTocLocal*
   Create/Update table of contents (section local variant).
 
 *<plug>(wiki-journal-index)*
@@ -1419,7 +1419,7 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *WikiTagSearch*  [options] [tag]
   List wiki pages that contain the desired `tag`. If the argument `tag` is not
   supplied, the command asks for input. See also |wiki-tags| for more
-  information on the tags feature and |WikiFzfTags| for an alternative search
+  information on the tags feature and |WikiTags| for an alternative search
   mechanism.
 
   Available options are (use |g:wiki_tag_search| to set default values):
@@ -1438,8 +1438,8 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   supplied, the command asks for input. This command uses the `make` function
   of |g:wiki_tag_parsers|.
 
-*<plug>(wiki-fzf-pages)*
-*WikiFzfPages*
+*<plug>(wiki-pages)*
+*WikiPages*
   Open |fzf| in find file mode for wiki files in current wiki or in the main
   wiki defined by |g:wiki_root|.
 
@@ -1465,16 +1465,16 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
   Page", and this term does not exist, then it will instead open a new page
   "My Fzf Page.wiki" (or similar, depending on the value of other options).
 
-*<plug>(wiki-fzf-tags)*
-*WikiFzfTags*
+*<plug>(wiki-tags)*
+*WikiTags*
   Open |fzf| and search for tags.
 
   One may pass additional options to fzf with the |g:wiki_fzf_tags_opts|
   option. This allows more fine grained control of fzf, e.g. to add
   a previewer.
 
-*<plug>(wiki-fzf-toc)*
-*WikiFzfToc*
+*<plug>(wiki-toc)*
+*WikiToc*
   Open |fzf| and list table of contents entries for the current wiki page.
 
 ==============================================================================
@@ -1847,7 +1847,7 @@ Related commands:
 - |WikiTagReload|
 - |WikiTagSearch|
 - |WikiTagRename|
-- |WikiFzfTags|
+- |WikiTags|
 
 Related settings:
 - |g:wiki_tag_list|

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -1318,12 +1318,12 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *WikiPageRename*
   Rename wiki page (will update all links to the page).
 
-*<plug>(wiki-generate-toc)*
-*WikiGenerateToc*
+*<plug>(wiki-toc-generate)*
+*WikiTocGenerate*
   Create/Update table of contents.
 
-*<plug>(wiki-generate-toc-local)*
-*WikiGenerateTocLocal*
+*<plug>(wiki-toc-generate-local)*
+*WikiTocGenerateLocal*
   Create/Update table of contents (section local variant).
 
 *<plug>(wiki-journal-index)*

--- a/lua/wiki/init.lua
+++ b/lua/wiki/init.lua
@@ -1,14 +1,28 @@
 local M = {}
 
+-- Returns shorten path
+local function filter(path)
+    local root = vim.g.wiki_root .. "/"
+    return path:gsub(root, "")
+end
+
+-- Returns full path
+local function unfilter(path)
+    local root = vim.g.wiki_root .. "/"
+    return root .. path
+end
+
 function M.get_pages()
     local res = {}
     local pages = vim.fn["wiki#page#get_all"]()
     for _, p in pairs(pages) do
-        table.insert(res, p[1])
+        local page = filter(p[1])
+        table.insert(res, page)
     end
     vim.ui.select(res,
         { prompt = "WikiPages> " },
         function(f)
+            f = unfilter(f)
             vim.cmd("edit " .. f)
         end)
 end
@@ -18,14 +32,14 @@ function M.get_tags()
     local tags = vim.fn["wiki#tags#get_all"]()
     for key, val in pairs(tags) do
         for _, file in pairs(val) do
-            local str = string.format("%s: %s:%s", key, file[1], file[2])
+            local str = string.format("%s:%s:%s", key, file[2], filter(file[1]))
             table.insert(res, str)
         end
     end
     vim.ui.select(res,
         { prompt = "WikiTags> " },
         function(t)
-            t = vim.split(t, ':')[2]
+            t = unfilter(vim.split(t, ':')[3])
             vim.cmd("edit " .. t)
         end)
     return res
@@ -36,13 +50,13 @@ function M.toc()
     local toc = vim.fn["wiki#toc#gather_entries"]()
     for _, hd in pairs(toc) do
         local indent = vim.fn["repeat"]('.', hd.level - 1)
-        local line = hd.lnum .. ': ' .. indent .. hd.header
+        local line = hd.lnum .. '|' .. indent .. hd.header
         table.insert(res, line)
     end
     vim.ui.select(res,
         { prompt = "WikiToc> ", },
         function(t)
-            t = vim.split(t, ':')[1]
+            t = vim.split(t, '|')[1]
             vim.cmd("execute " .. t)
         end)
 end

--- a/lua/wiki/init.lua
+++ b/lua/wiki/init.lua
@@ -1,0 +1,50 @@
+local M = {}
+
+function M.get_pages()
+    local res = {}
+    local pages = vim.fn["wiki#page#get_all"]()
+    for _, p in pairs(pages) do
+        table.insert(res, p[1])
+    end
+    vim.ui.select(res,
+        { prompt = "WikiPages> " },
+        function(f)
+            vim.cmd("edit " .. f)
+        end)
+end
+
+function M.get_tags()
+    local res = {}
+    local tags = vim.fn["wiki#tags#get_all"]()
+    for key, val in pairs(tags) do
+        for _, file in pairs(val) do
+            local str = string.format("%s: %s:%s", key, file[1], file[2])
+            table.insert(res, str)
+        end
+    end
+    vim.ui.select(res,
+        { prompt = "WikiTags> " },
+        function(t)
+            t = vim.split(t, ':')[2]
+            vim.cmd("edit " .. t)
+        end)
+    return res
+end
+
+function M.toc()
+    local res = {}
+    local toc = vim.fn["wiki#toc#gather_entries"]()
+    for _, hd in pairs(toc) do
+        local indent = vim.fn["repeat"]('.', hd.level - 1)
+        local line = hd.lnum .. ': ' .. indent .. hd.header
+        table.insert(res, line)
+    end
+    vim.ui.select(res,
+        { prompt = "WikiToc> ", },
+        function(t)
+            t = vim.split(t, ':')[1]
+            vim.cmd("execute " .. t)
+        end)
+end
+
+return M

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -65,6 +65,11 @@ call wiki#init#option('wiki_month_names', [
       \])
 call wiki#init#option('wiki_resolver', 'wiki#url#wiki#resolver')
 call wiki#init#option('wiki_root', '')
+if has('nvim')
+  call wiki#init#option('wiki_select_method', 'ui_select')
+else
+  call wiki#init#option('wiki_select_method', 'fzf')
+endif
 call wiki#init#option('wiki_tag_list', { 'output' : 'loclist' })
 call wiki#init#option('wiki_tag_search', { 'output' : 'loclist' })
 call wiki#init#option('wiki_tag_parsers', [g:wiki#tags#default_parser])
@@ -90,7 +95,7 @@ command! WikiIndex    call wiki#goto_index()
 command! WikiOpen     call wiki#page#open()
 command! WikiReload   call wiki#reload()
 command! WikiJournal  call wiki#journal#open()
-if has('nvim')
+if has('nvim') && g:wiki_select_method == 'ui_select'
   command! WikiPages lua require('wiki').get_pages()
   command! WikiTags lua require('wiki').get_tags()
 else

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -90,18 +90,19 @@ command! WikiIndex    call wiki#goto_index()
 command! WikiOpen     call wiki#page#open()
 command! WikiReload   call wiki#reload()
 command! WikiJournal  call wiki#journal#open()
-command! WikiFzfPages call wiki#fzf#pages()
-command! WikiFzfTags  call wiki#fzf#tags()
-command! WikiPages call luaeval("require('wiki').get_pages()")
-command! WikiTags  call luaeval("require('wiki').get_tags()")
+if has('nvim')
+  command! WikiPages  call luaeval("require('wiki').get_pages()")
+  command! WikiTags   call luaeval("require('wiki').get_tags()")
+else
+  command! WikiPages  call wiki#fzf#pages()
+  command! WikiTags   call wiki#fzf#tags()
+endif
 
 " Initialize mappings
 nnoremap <silent> <plug>(wiki-index)     :WikiIndex<cr>
 nnoremap <silent> <plug>(wiki-open)      :WikiOpen<cr>
 nnoremap <silent> <plug>(wiki-journal)   :WikiJournal<cr>
 nnoremap <silent> <plug>(wiki-reload)    :WikiReload<cr>
-nnoremap <silent> <plug>(wiki-fzf-pages) :WikiFzfPages<cr>
-nnoremap <silent> <plug>(wiki-fzf-tags)  :WikiFzfTags<cr>
 nnoremap <silent> <plug>(wiki-pages)     :WikiPages<cr>
 nnoremap <silent> <plug>(wiki-tags)      :WikiTags<cr>
 

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -92,6 +92,8 @@ command! WikiReload   call wiki#reload()
 command! WikiJournal  call wiki#journal#open()
 command! WikiFzfPages call wiki#fzf#pages()
 command! WikiFzfTags  call wiki#fzf#tags()
+command! WikiPages call luaeval("require('wiki').get_pages()")
+command! WikiTags  call luaeval("require('wiki').get_tags()")
 
 " Initialize mappings
 nnoremap <silent> <plug>(wiki-index)     :WikiIndex<cr>
@@ -100,6 +102,8 @@ nnoremap <silent> <plug>(wiki-journal)   :WikiJournal<cr>
 nnoremap <silent> <plug>(wiki-reload)    :WikiReload<cr>
 nnoremap <silent> <plug>(wiki-fzf-pages) :WikiFzfPages<cr>
 nnoremap <silent> <plug>(wiki-fzf-tags)  :WikiFzfTags<cr>
+nnoremap <silent> <plug>(wiki-pages)     :WikiPages<cr>
+nnoremap <silent> <plug>(wiki-tags)      :WikiTags<cr>
 
 " Apply default mappings
 let s:mappings = index(['all', 'global'], g:wiki_mappings_use_defaults) >= 0

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -91,11 +91,11 @@ command! WikiOpen     call wiki#page#open()
 command! WikiReload   call wiki#reload()
 command! WikiJournal  call wiki#journal#open()
 if has('nvim')
-  command! WikiPages  call luaeval("require('wiki').get_pages()")
-  command! WikiTags   call luaeval("require('wiki').get_tags()")
+  command! WikiPages lua require('wiki').get_pages()
+  command! WikiTags lua require('wiki').get_tags()
 else
-  command! WikiPages  call wiki#fzf#pages()
-  command! WikiTags   call wiki#fzf#tags()
+  command! WikiPages call wiki#fzf#pages()
+  command! WikiTags call wiki#fzf#tags()
 endif
 
 " Initialize mappings


### PR DESCRIPTION
> related to: #274 

* Removing `WikiFzf{Pages,Tags,Toc}` in favor of `Wiki{Pages,Tags,Toc}`

This uses on Neovim `vim.ui.select` and on vim `junegunn/fzf`.

* Renaming `WikiPageToc` and `WikiPageLocToc` to `WikiGenerateToc` and `WikiGenerateLocToc`

This is for prefenting user confusion with `WikiToc` and also make more clear the outcome of the command.

## Demos

### with [FzfLua](https://github.com/ibhagwan/fzf-lua)

`WikiPages`
![pages](https://user-images.githubusercontent.com/96259932/226139905-b8662499-144b-4546-ab8f-64c065d824ae.gif)

`WikiTags`
![tags](https://user-images.githubusercontent.com/96259932/226139950-2cec9585-1798-45df-835b-1e9f22de6cea.gif)

`WikiToc`
![toc](https://user-images.githubusercontent.com/96259932/226139953-b1762ba0-4819-428d-a125-56db16e9426a.gif)

### with [Telescope](https://github.com/nvim-telescope/telescope.nvim)

`WikiPages`
![pages](https://user-images.githubusercontent.com/96259932/226140541-29ea432d-321b-42b1-8d1f-71394f2fd0fe.gif)

`WikiTags`
![tags](https://user-images.githubusercontent.com/96259932/226140498-c43bcd09-20c4-4b48-8326-6c47bd3680da.gif)

`WikiToc`
![toc](https://user-images.githubusercontent.com/96259932/226140525-d21c6a71-48d6-4a30-ac71-5211cd251dd7.gif)
