### PR TITLE
Lua: normalize paths in ui.select feature

### DIFF
--- a/lua/wiki/init.lua
+++ b/lua/wiki/init.lua
@@ -1,10 +1,12 @@
 local M = {}
 
+local function normalize_path(path)
+  return vim.fn.substitute(vim.fn.expand(vim.g.wiki_root .. "/"), "\\/$", "", nil)
+end
+
 -- Returns shorten path
 local function filter(path)
-  local root = vim.fn
-    .substitute(vim.fn
-      .expand(vim.g.wiki_root .. "/"), "\\/$", "", nil)
+  local root = normalize_path(path)
   return path:gsub(root, "")
 end
 

--- a/lua/wiki/init.lua
+++ b/lua/wiki/init.lua
@@ -2,7 +2,9 @@ local M = {}
 
 -- Returns shorten path
 local function filter(path)
-  local root = vim.g.wiki_root .. "/"
+  local root = vim.fn
+    .substitute(vim.fn
+      .expand(vim.g.wiki_root .. "/"), "\\/$", "", nil)
   return path:gsub(root, "")
 end
 


### PR DESCRIPTION
The new lua functions weren't working for me because I declared my root as `~/Wiki/`,  both the home relative path and trailing slash were tripping up the UI select and file picker.

Here's a fix for that.