### PR TITLE
Update README.md - Removed broken link in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Note: Some features require a recent version of Vim (>= 8.1) or NeoVim (>= 0.5).
 
 - [Quick Start](#quick-start)
 - [Features](#features)
-- [Related projects](#related-projects)
 - [Acknowledgements](#acknowledgements)
 
 # Quick Start


### PR DESCRIPTION
I removed the broken link to "Related Projects" in the Table of Contents. The corresponding section of the README file had been previously deleted in earlier commits, and the link was no longer valid.