### PR TITLE
Generalize Toc related tasks to function with other filetypes

### DIFF
--- a/autoload/wiki/rx.vim
+++ b/autoload/wiki/rx.vim
@@ -23,8 +23,12 @@ let wiki#rx#list_define = '::\%(\s\|$\)'
 let wiki#rx#comment = '^\s*%%.*$'
 let wiki#rx#todo = '\C\<\%(TODO\|STARTED\|FIXME\)\>:\?'
 let wiki#rx#done = '\C\<\%(OK\|DONE\|FIXED\)\>:\?'
-let wiki#rx#header = '^#\{1,6}\s*[^#].*'
-let wiki#rx#header_items = '^\(#\{1,6}\)\s*\([^#].*\)\s*$'
+let wiki#rx#header_md_atx = '^#\{1,6}\s*[^#].*'
+let wiki#rx#header_md_atx_items = '^\(#\{1,6}\)\s*\([^#].*\)\s*$'
+let wiki#rx#header_org = '^\*\{1,6}\s*[^\*].*'
+let wiki#rx#header_org_items = '^\(\*\{1,6}\)\s*\([^\*].*\)\s*$'
+let wiki#rx#header_adoc = '^=\{1,6}\s*[^=].*'
+let wiki#rx#header_adoc_items = '^\(=\{1,6}\)\s*\([^=].*\)\s*$'
 let wiki#rx#bold = wiki#rx#surrounded(
       \ '[^*`[:space:]]\%([^*`]*[^*`[:space:]]\)\?', '*')
 let wiki#rx#italic = wiki#rx#surrounded(

--- a/autoload/wiki/toc.vim
+++ b/autoload/wiki/toc.vim
@@ -44,19 +44,19 @@ function! wiki#toc#gather_entries(...) abort " {{{1
   "   at_lnum:    Return the entry that covers specified line
   " Output: ToC entries
 
-  let l:header = {}
+  let l:hd = {}
   if &filetype == 'asciidoc'
-    let l:header.achor = '='
-    let l:header.regex = g:wiki#rx#header_adoc
-    let l:header.items = g:wiki#rx#header_adoc_items
+    let l:hd.achor = '='
+    let l:hd.regex = g:wiki#rx#header_adoc
+    let l:hd.items = g:wiki#rx#header_adoc_items
   elseif &filetype == 'markdown'
-    let l:header.achor = '#'
-    let l:header.regex = g:wiki#rx#header_md_atx
-    let l:header.items = g:wiki#rx#header_md_atx_items
+    let l:hd.achor = '#'
+    let l:hd.regex = g:wiki#rx#header_md_atx
+    let l:hd.items = g:wiki#rx#header_md_atx_items
   elseif &filetype == 'org'
-    let l:header.achor = '*'
-    let l:header.regex = g:wiki#rx#header_org
-    let l:header.items = g:wiki#rx#header_org_items
+    let l:hd.achor = '*'
+    let l:hd.regex = g:wiki#rx#header_org
+    let l:hd.items = g:wiki#rx#header_org_items
   endif
 
   let l:opts = extend(a:0 > 0 ? a:1 : {}, #{
@@ -83,17 +83,17 @@ function! wiki#toc#gather_entries(...) abort " {{{1
     endif
     if l:preblock | continue | endif
 
-    " Get line - check for header
-    if l:line !~# l:header.regex | continue | endif
+    " Get line - check for hd
+    if l:line !~# l:hd.regex | continue | endif
 
-    " Parse current header
-    let l:level = len(matchstr(l:line, '^' . l:header.achor . '*'))
-    let l:header = matchlist(l:line, l:header.items)[2]
-    let l:anchors[l:level] = l:header
+    " Parse current hd
+    let l:level = len(matchstr(l:line, '^' . l:hd.achor . '*'))
+    let l:header = matchlist(l:line, l:hd.items)[2]
+    let l:anchors[l:level] = l:hd
 
     " Add the new entry
     call add(l:entries, {
-          \ 'anchor' : join(l:anchors[:l:level], l:header.achor),
+          \ 'anchor' : join(l:anchors[:l:level], l:hd.achor),
           \ 'anchors' : copy(l:anchors[1:l:level]),
           \ 'header': l:header,
           \ 'level' : l:level,


### PR DESCRIPTION
fixes: #288

PR changes:
* Makes `WikiToc` works with other filetypes
* Makes `WikiTocGenerate` and `WikiTocGenerateLocal` works with other filetypes

## Asciidoc

Asciidoc works without problems with `WikiToc`. For `WikiTocGenerate`, since asciidoc supports natively table of contents, I've implemented a minimal check that parse the lines between the first level heading and the next heading, and searches for some special keywords that asciidoc can understand. If no first level heading is found, it is created a new one with the name of the file. Then it will append to it the special keywords. It doesn't do anything if it found everything.

### Showcase

https://user-images.githubusercontent.com/96259932/233493622-c37fd33b-9ee7-42d5-a13e-fcfa3c0db1b3.mov

## Org

Org works without problems with `WikiToc`. For `WikiTocGenerate` I've tried to make it as compatible as possible with what I've found online, but since his poor standardization outside of Emacs and my ignorance of the filetype I don't think is the best implementation. It will append on top of the file the string `#+OPTION toc: g:wiki_toc_depth`.

### Showcase

https://user-images.githubusercontent.com/96259932/233494814-b6cdc6ac-0362-4018-ab62-18027998d7f6.mov

## Next Step

If you like the idea I'll open a new issue to discuss the feature. I've in mind to generalise the plugin even more and come to a point were the user need only to specify a directory and a dictionary of filetypes he wants and that's it. In other words having a multi-filetype wiki were if I press enter in a markdown file it create a markdown link and if I am in an asciidoc file it does an asciidoc file.

I was thinking of something like this:
```vim
" renaming g:wiki_filetypes to something like g:wiki_extentions
let g:wiki_filetypes = {
  \ 'markdown' : {
      \ 'link_type' : 'wiki'|'md',
      \ 'extension' : 'md',
      \ 'heading'   : 'atx',
  \ },
  \ 'asciidoc' : {
     \ 'link_type' : 'wathever'
     \ 'extention' : 'adoc'
  \ },
  \ 'org' : {
     \ 'extension' : 'org'
  \ },
}
```