### PR TITLE
Support multi-filetype wikis with g:wiki_link_creation

### DIFF
--- a/autoload/wiki/complete.vim
+++ b/autoload/wiki/complete.vim
@@ -119,7 +119,7 @@ function! s:completer_wikilink.complete_page(regex) dict abort " {{{2
 
   call map(l:cands, 'strpart(v:val, strlen(l:root)+1)')
   call map(l:cands,
-        \ empty(g:wiki_link_extension)
+        \ empty(wiki#link#get_creator('url_extension'))
         \ ? 'l:pre . fnamemodify(v:val, '':r'')'
         \ : 'l:pre . v:val')
   call s:filter_candidates(l:cands, a:regex)

--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -64,6 +64,18 @@ endfunction
 
 "}}}1
 
+function! wiki#link#get_creator(...) abort " {{{1
+  let l:ft = expand('%:e')
+  if empty(l:ft) || index(g:wiki_filetypes, l:ft) < 0
+    let l:ft = g:wiki_filetypes[0]
+  endif
+  let l:c = get(g:wiki_link_creation, l:ft, g:wiki_link_creation._)
+
+  return a:0 > 0 ? l:c[a:1] : l:c
+endfunction
+
+" }}}1
+
 function! wiki#link#show(...) abort "{{{1
   let l:link = wiki#link#get()
 
@@ -162,16 +174,16 @@ endfunction
 " }}}1
 
 function! wiki#link#template(url, text) abort " {{{1
-  "
   " Pick the relevant link template command to use based on the users
   " settings. Default to the wiki style one if its not set.
-  "
+
   try
-    return wiki#link#{g:wiki_link_target_type}#template(a:url, a:text)
+    let l:type = wiki#link#get_creator('link_type')
+    return wiki#link#{l:type}#template(a:url, a:text)
   catch /E117:/
     call wiki#log#warn(
-          \ 'Link target type does not exist: ' . g:wiki_link_target_type,
-          \ 'See ":help g:wiki_link_target_type" for help'
+          \ 'Target link type does not exist: ' . l:type,
+          \ 'See ":help g:wiki_link_creation" for help'
           \)
   endtry
 endfunction

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -371,8 +371,6 @@ syntax highlighting and folding. Recommended settings if you want to use
 this: >vim
 
   let g:wiki_filetypes = ['wiki']
-  let g:wiki_link_target_type = ''
-  let g:wiki_link_extension = ''
 
 lists.vim ~
 https://github.com/lervag/lists.vim
@@ -496,13 +494,13 @@ OPTIONS                                                   *wiki-config-options*
           \}
 
 *g:wiki_filetypes*
-  List of filetypes for which |wiki.vim| should be enabled. If you want to
-  make Markdown the default filetype, add it as the first element to the list,
-  e.g.: >vim
+  List of filetype extensions for which |wiki.vim| should be enabled. Notice
+  that file extensions are not always the same as the filetype. For example,
+  the common extension for Markdown is `.md`, whereas the filetype is called
+  `markdown`. The option should list the file extensions.
 
-    let g:wiki_filetypes = ['md', 'wiki']
-<
-  See also |g:wiki_link_extension|, which is often relevant in many filetypes.
+  The first element of the list is considered the default filetype where that
+  is relevant.
 
   Default: `['md']`
 
@@ -731,11 +729,76 @@ OPTIONS                                                   *wiki-config-options*
           \ 'link_url_parser': { b, d, p -> 'journal:' . d }
           \}
 
-*g:wiki_link_extension*
-  Specify the extension that should be applied to wiki links. This should be
-  in the format `.ext`, e.g. `.md` or `.wiki`.
+*g:wiki_link_creation*
+  A dictionary to configure how links are created from text for any given
+  filetype. Filetypes are specified by file extension so as to correspond with
+  |g:wiki_filetypes|, that is, we use `md` and not `markdown`.
 
-  Default: `'.md'`
+  The corresponding value is a dictionary of options. If there is no key for
+  the current filetype, then the fallback key `"_"` is used.
+
+  The valid options are:
+
+    link_type ~
+      A string that specifies the type of link to create. Possible values:
+
+        `md` (|wiki-link-markdown|)
+          Markdown style links.
+
+        `wiki` (|wiki-link-wiki|)
+          Wiki style links.
+
+        `org` (|wiki-link-orgmode|)
+          Orgmode style links.
+
+        `adoc_xref_bracket` (|wiki-link-adoc-xref|)
+        `adoc_xref_inline`
+          AsciiDoc cross-reference style links (angled brackets style or
+          inline `xref:...` style).
+
+    url_extension ~
+      A string that, if not empty, will be appended to the target url.
+
+    url_transform ~
+      A |Funcref| for a function used to transform the text to the desired
+      URL. This can also be an |anonymous-function|. If it is undefined, the
+      the original text will be taken as the URL.
+        The function requires a single string argument and should return the
+      target URL without any file extension. This is useful e.g. to substitute
+      space characters, apply URL encoding, or similar.
+        An example may be useful. The following configuration will convert all
+      characters to lowercase and substitute each set of one or more spaces
+      into a single dash character. >vim
+
+        let g:wiki_link_creation = {
+              \ 'markdown': {
+              \   'link_type': 'md',
+              \   'url_extension': '.md',
+              \   'url_transform': { x ->
+              \     substitute(tolower(x), '\s\+', '-', 'g') },
+              \ },
+              \}
+<
+  Default: >vim
+
+    let g:wiki_link_creation = {
+          \ 'md': {
+          \   'link_type': 'md',
+          \   'url_extension': '.md',
+          \ },
+          \ 'org': {
+          \   'link_type': 'org',
+          \   'url_extension': '.org',
+          \ },
+          \ 'adoc': {
+          \   'link_type': 'adoc_xref_bracket',
+          \   'url_extension': '',
+          \ },
+          \ '_': {
+          \   'link_type': 'wiki',
+          \   'url_extension': '',
+          \ },
+          \}
 
 *g:wiki_link_toggle_on_follow*
   This option allows disabling the toggle behaviour in |WikiLinkFollow| where
@@ -744,29 +807,6 @@ OPTIONS                                                   *wiki-config-options*
   transform text into links.
 
   Default: 1
-
-*g:wiki_link_target_type*
-  This option may be used to pick the default style of link that will be used.
-
-  Available styles for the default target type are:
-
-    `md` (|wiki-link-markdown|)
-      Markdown style links.
-
-    `wiki` (|wiki-link-wiki|)
-      Wiki style links.
-
-    `org` (|wiki-link-orgmode|)
-      Orgmode style links.
-
-    `adoc_xref_bracket` (|wiki-link-adoc-xref|)
-    `adoc_xref_inline`
-      AsciiDoc cross-reference style links (angled brackets style or inline
-      `xref:...` style).
-
-  Toggling between link types can still be achieved using |WikiLinkToggle|.
-
-  Default: `'md'`
 
 *g:wiki_link_toggles*
   This option specifies the template for toggling a specific type of link with
@@ -803,69 +843,6 @@ OPTIONS                                                   *wiki-config-options*
           \ 'shortcite': 'wiki#link#md#template',
           \ 'url': 'wiki#link#md#template',
           \}
-
-*g:wiki_map_create_page*
-  This option may be used to specify a map or transformation for page names
-  provided to |WikiOpen|. For example: >vim
-
-    let g:wiki_map_create_page = 'MyFunction'
-
-    function MyFunction(name) abort
-      let l:name = wiki#get_root() . '/' . a:name
-
-      " If the file is new, then append the current date
-      return filereadable(l:name)
-            \ ? a:name
-            \ : a:name . '_' . strftime('%Y%m%d')
-    endfunction
-<
-  With the above setting, if one enters a page name "foo" for |WikiOpen| on
-  the date 2020-04-11, the page "foo_20200411" will be created.
-
-  The option value should be a string (the `name` of the function) or
-  a |Funcref|. The latter only works in neovim when the option is defined from
-  Lua with |lua-vim-variables|, e.g. >lua
-
-    vim.g.wiki_map_create_page = function(x) return x:lower() end
-<
-  Default: `''`
-
-*g:wiki_map_text_to_link*
-  This option may be used to transform text before creating a new link with
-  |WikiLinkToggle| (or related mappings). The option value should be a string
-  (the `name` of the function) or a |Funcref|. The latter only works in neovim
-  when the option is defined from Lua with |lua-vim-variables|, similar to
-  this: >lua
-
-    vim.g.wiki_map_text_to_link = function(x)
-      return { x:lower(), x }
-    end
-<
-  The specified function must take a single argument and return two values.
-  The following signature should be descriptive: >vim
-
-    let [url, text] = TextToLink(text_raw)
-<
-  Here `text_raw` is the text that should be transformed to a link composed
-  of `url` and `text`. An example may be more enlightening: >vim
-
-    let g:wiki_map_text_to_link = 'MyTextToLink'
-
-    function MyTextToLink(text) abort
-      return [substitute(tolower(a:text), '\s\+', '-', 'g'), a:text]
-    endfunction
-<
-  This specifies that transformations will look like the following,
-  given that other settings are at their defaults: >
-
-    Hello world  →    [[hello-world|Hello World]]
-    Some text    →    [[some-text|Some text]]
-<
-  Note: The actual resulting link also depends on these options:
-        - |g:wiki_link_extension|
-        - |g:wiki_link_target_type|
-
-  Default: `''`
 
 *g:wiki_mappings_use_defaults*
   Whether or not to use default mappings (see |wiki-mappings-default|). The
@@ -1223,9 +1200,11 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *<plug>(wiki-open)*
 *WikiOpen*
   Open (or create) a page. Asks for user input to specify the page name. When
-  not already inside a wiki, the wiki root is given by |g:wiki_root|. If
-  |g:wiki_map_create_page| is specified, it will be used to transform the
-  input name before opening/creating the page.
+  not already inside a wiki, the wiki root is given by |g:wiki_root|.
+
+  The settings from |g:wiki_link_creation| are applied based on the current
+  'filetype'. If the filetype is not specified or if it is not listed in
+  |g:wiki_filetypes|, then the first filetype in this list is assumed.
 
 *<plug>(wiki-journal)*
 *WikiJournal*
@@ -1313,11 +1292,11 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *<plug>(wiki-link-toggle-operator)*  |map-operator|
 *WikiLinkToggle*
   Toggle a link. That is, this converts a link from one type to another based
-  on the value of |g:wiki_link_toggles|. Pure text is converted to a link of
-  type |g:wiki_link_target_type|, and if |g:wiki_map_text_to_link| is
-  specified, it will be used to transform the link before creating it.
+  on the value of |g:wiki_link_toggles|.
 
-  The following rules apply when converting text to a link.
+  Additionally, this command and the mappings can be used to convert regular
+  text to a link. The behaviour is controlled by |g:wiki_link_creation| and
+  follows the following set of rules.
 
     If we are inside the journal: ~
 
@@ -1375,7 +1354,7 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 *<plug>(wiki-journal-index)*
 *WikiJournalIndex*
   Insert a sorted list of links to all journal pages below the cursor. It uses
-  the link style specified by |g:wiki_link_target_type|.
+  the link type specified in |g:wiki_link_creation| for the current filetype.
 
 *<plug>(wiki-journal-next)*
 *WikiJournalNext*
@@ -1426,8 +1405,11 @@ the commands are also available as mappings of the form `<plug>(wiki-[name])`.
 
   -link_ext_replace ~
     Set to true to replace in-wiki link extensions with html. This enables
-    in-browser wiki navigation. Requires `ext` be set to `html` and for
-    |g:wiki_link_extension| to be non-empty to have any meaningful effect.
+    in-browser wiki navigation, but for it to work well, it requires that:
+
+      1. `-ext` is set to `html`, and
+      2. |g:wiki_link_creation| should have a `url_transform` that appends
+         the extension.
 
   -output ~
     Set output directory where the exported file is stored. Relative paths are
@@ -1601,8 +1583,8 @@ The mappings that act on links are listed in |wiki-mappings-default|. The most
 notable default mappings are:
 - A link may be followed with `<cr>`.
 - `<cr>` used on normal text (not on a link) will transform the text into
-  a link of the type specified by |g:wiki_link_target_type|. This also works
-  in visual mode.
+  a link of the type specified by |g:wiki_link_creation|. This also works in
+  visual mode.
 - Similarly, `gl` may be used to turn operated text into a link.
 - One may use `<bs>` to navigate back after following a link.
 - `<leader>wf` can be used to transform a link between different types (see

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -44,8 +44,24 @@ call wiki#init#option('wiki_journal_index', {
       \ 'link_text_parser': { b, d, p -> d },
       \ 'link_url_parser': { b, d, p -> 'journal:' . d }
       \})
-call wiki#init#option('wiki_link_extension', '.md')
-call wiki#init#option('wiki_link_target_type', 'md')
+call wiki#init#option('wiki_link_creation', {
+      \ 'md': {
+      \   'link_type': 'md',
+      \   'url_extension': '.md',
+      \ },
+      \ 'org': {
+      \   'link_type': 'org',
+      \   'url_extension': '.org',
+      \ },
+      \ 'adoc': {
+      \   'link_type': 'adoc_xref_bracket',
+      \   'url_extension': '',
+      \ },
+      \ '_': {
+      \   'link_type': 'wiki',
+      \   'url_extension': '',
+      \ },
+      \})
 call wiki#init#option('wiki_link_toggle_on_follow', 1)
 call wiki#init#option('wiki_link_toggles', {
       \ 'wiki': 'wiki#link#md#template',
@@ -57,8 +73,6 @@ call wiki#init#option('wiki_link_toggles', {
       \ 'shortcite': 'wiki#link#md#template',
       \ 'url': 'wiki#link#md#template',
       \})
-call wiki#init#option('wiki_map_create_page', '')
-call wiki#init#option('wiki_map_text_to_link', '')
 call wiki#init#option('wiki_mappings_use_defaults', 'all')
 call wiki#init#option('wiki_month_names', [
       \ 'January', 'February', 'March', 'April', 'May', 'June', 'July',

--- a/test/init.vim
+++ b/test/init.vim
@@ -11,5 +11,3 @@ let g:testroot = fnamemodify(expand('<cfile>'), ':p:h:h')
 let g:wiki_cache_persistent = 0
 
 let g:wiki_filetypes = ['wiki']
-let g:wiki_link_target_type = 'wiki'
-let g:wiki_link_extension = ''

--- a/test/test-complete/test-markdown.vim
+++ b/test/test-complete/test-markdown.vim
@@ -1,8 +1,6 @@
 source ../init.vim
 
 let g:wiki_filetypes = ['md']
-let g:wiki_link_extension = '.md'
-let g:wiki_link_target_type = 'md'
 filetype plugin indent on
 
 runtime plugin/wiki.vim

--- a/test/test-init/test-buffer-root.vim
+++ b/test/test-init/test-buffer-root.vim
@@ -2,9 +2,10 @@ source ../init.vim
 
 let g:wiki_root = g:testroot . '/wiki-basic'
 let g:wiki_filetypes = ['wiki', 'md']
-let g:wiki_link_extension = '.wiki'
 
 runtime plugin/wiki.vim
+
+let g:wiki_link_creation._.url_extension = '.wiki'
 
 silent edit test.md
 

--- a/test/test-init/test-proper-extension.vim
+++ b/test/test-init/test-proper-extension.vim
@@ -2,9 +2,10 @@ source ../init.vim
 
 let g:wiki_root = g:testroot . '/wiki-basic'
 let g:wiki_filetypes = ['wiki', 'md']
-let g:wiki_link_extension = '.wiki'
 
 runtime plugin/wiki.vim
+
+let g:wiki_link_creation._.url_extension = '.wiki'
 
 silent edit test.md
 silent call wiki#goto_index()

--- a/test/test-links/test-adoc.vim
+++ b/test/test-links/test-adoc.vim
@@ -1,18 +1,11 @@
 source ../init.vim
 
-let g:wiki_link_target_type = 'adoc_xref_bracket'
 let g:wiki_filetypes = ['adoc']
 
 runtime plugin/wiki.vim
 
 
-" Test toggle on selection (g:wiki_link_extension should not matter here)
-silent edit ../wiki-adoc/index.adoc
-normal! 15G
-silent execute "normal f.2lve\<Plug>(wiki-link-toggle-visual)"
-call assert_equal('Some text, cf. <<foo.adoc#,foo>>.', getline('.'))
-bwipeout!
-let g:wiki_link_extension = '.adoc'
+" Test toggle on selection
 silent edit ../wiki-adoc/index.adoc
 normal! 15G
 silent execute "normal f.2lve\<Plug>(wiki-link-toggle-visual)"

--- a/test/test-links/test-create-special.vim
+++ b/test/test-links/test-create-special.vim
@@ -1,12 +1,10 @@
 source ../init.vim
 
-let g:wiki_map_text_to_link = 'TextToLink'
-
-function TextToLink(text) abort
-  return [substitute(tolower(a:text), '\s\+', '-', 'g'), a:text]
-endfunction
-
 runtime plugin/wiki.vim
+
+" Specify url transformer
+let g:wiki_link_creation._.url_transform =
+      \ { x -> substitute(tolower(x), '\s\+', '-', 'g') }
 
 " Test toggle normal on regular markdown links using wiki style links
 silent edit ../wiki-basic/index.wiki
@@ -31,7 +29,7 @@ call assert_equal('[[pokémon|Pokémon]]', getline('.'))
 
 " Test toggle normal on regular markdown links using md style links
 bwipeout!
-let g:wiki_link_target_type = 'md'
+let g:wiki_link_creation._.link_type = 'md'
 silent edit ../wiki-basic/index.wiki
 normal! 3G
 silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
@@ -40,8 +38,7 @@ call assert_equal('[This is a wiki](this-is-a-wiki).', getline('.'))
 " Test toggle normal on regular markdown links using md style links with the
 " markdown extension
 bwipeout!
-let g:wiki_link_target_type = 'md'
-let g:wiki_link_extension = '.md'
+let g:wiki_link_creation._.url_extension = '.md'
 silent edit ../wiki-basic/index.wiki
 normal! 3G
 silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
@@ -53,8 +50,8 @@ call assert_equal('[TestSubDirLink/](testsubdirlink/)', getline('.'))
 " Test toggle normal on regular orgmode links using md style links with the
 " orgmode extension
 bwipeout!
-let g:wiki_link_target_type = 'org'
-let g:wiki_link_extension = '.org'
+let g:wiki_link_creation._.link_type = 'org'
+let g:wiki_link_creation._.url_extension = '.org'
 silent edit ../wiki-basic/index.wiki
 normal! 3G
 silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
@@ -65,8 +62,8 @@ call assert_equal('[[testsubdirlink/][TestSubDirLink/]]', getline('.'))
 
 " Test toggle normal on regular markdown links using md style links in journal
 bwipeout!
-let g:wiki_link_target_type = 'md'
-let g:wiki_link_extension = ''
+let g:wiki_link_creation._.link_type = 'md'
+let g:wiki_link_creation._.url_extension = ''
 silent edit ../wiki-basic/index.wiki
 normal! 3G
 silent execute 'let b:wiki.in_journal=1'
@@ -74,27 +71,13 @@ silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
 call assert_equal('[This is a wiki](this-is-a-wiki).', getline('.'))
 
 " Test toggle normal on regular markdown links using md style links in journal
-" without `g:wiki_map_text_to_link`
+" without url transformer
 bwipeout!
-let g:wiki_link_target_type = 'md'
-let g:wiki_link_extension = ''
-let g:wiki_map_text_to_link = ''
+unlet g:wiki_link_creation._.url_transform
 silent edit ../wiki-basic/index.wiki
 normal! 3G
 silent execute 'let b:wiki.in_journal=1'
 silent execute "normal vt.\<Plug>(wiki-link-toggle-visual)"
 call assert_equal('[This is a wiki](This is a wiki).', getline('.'))
-
-bwipeout!
-let g:wiki_link_target_type = 'md'
-let g:wiki_link_extension = ''
-let g:wiki_map_text_to_link = 'TextToLink2'
-function TextToLink2(text) abort
-  return [a:text, substitute(a:text, '-', ' ', 'g')]
-endfunction
-silent edit ../wiki-basic/index.wiki
-normal! 14G
-silent execute 'normal glt.'
-call assert_equal('[This is a wiki](This-is-a-wiki).', getline('.'))
 
 call wiki#test#finished()

--- a/test/test-links/test-open-markdown.vim
+++ b/test/test-links/test-open-markdown.vim
@@ -1,15 +1,12 @@
 source ../init.vim
 
-function MyFunction(text) abort
-  return substitute(tolower(a:text), '\s\+', '-', 'g')
-endfunction
-
 let g:wiki_filetypes = ['md']
-let g:wiki_link_extension = '.md'
-let g:wiki_map_create_page = 'MyFunction'
 let g:wiki_root = g:testroot . '/wiki-basic'
 
 runtime plugin/wiki.vim
+
+let g:wiki_link_creation.md.url_transform =
+      \ { x -> substitute(tolower(x), '\s\+', '-', 'g') }
 
 silent WikiIndex
 call assert_equal(g:wiki_root . '/index.md', expand('%'))

--- a/test/test-links/test-open-orgmode.vim
+++ b/test/test-links/test-open-orgmode.vim
@@ -1,15 +1,12 @@
 source ../init.vim
 
-function MyFunction(text) abort
-  return substitute(tolower(a:text), '\s\+', '-', 'g')
-endfunction
-
 let g:wiki_filetypes = ['org']
-let g:wiki_link_extension = '.org'
-let g:wiki_map_create_page = 'MyFunction'
 let g:wiki_root = g:testroot . '/wiki-basic'
 
 runtime plugin/wiki.vim
+
+let g:wiki_link_creation.org.url_transform =
+      \ { x -> substitute(tolower(x), '\s\+', '-', 'g') }
 
 silent WikiIndex
 call assert_equal(g:wiki_root . '/index.org', expand('%'))

--- a/test/test-markdown/test.vim
+++ b/test/test-markdown/test.vim
@@ -2,8 +2,6 @@ source ../init.vim
 
 " Initial load of wiki.vim
 let g:wiki_filetypes = ['md']
-let g:wiki_link_extension = '.md'
-let g:wiki_link_target_type = 'md'
 runtime plugin/wiki.vim
 
 " Test open existing wiki with no settings

--- a/test/test-orgmode/test.vim
+++ b/test/test-orgmode/test.vim
@@ -2,8 +2,6 @@ source ../init.vim
 
 " Initial load of wiki.vim
 let g:wiki_filetypes = ['org']
-let g:wiki_link_extension = '.org'
-let g:wiki_link_target_type = 'org'
 runtime plugin/wiki.vim
 
 " Test open existing wiki with no settings

--- a/test/test-page/test-rename-md.vim
+++ b/test/test-page/test-rename-md.vim
@@ -1,6 +1,5 @@
 source ../init.vim
 let g:wiki_filetypes = ['md']
-let g:wiki_link_extension = '.md'
 runtime plugin/wiki.vim
 
 silent edit wiki-tmp/test\ 2.md

--- a/test/test-page/test-rename-org.vim
+++ b/test/test-page/test-rename-org.vim
@@ -1,6 +1,5 @@
 source ../init.vim
 let g:wiki_filetypes = ['org']
-let g:wiki_link_extension = '.org'
 runtime plugin/wiki.vim
 
 silent edit wiki-tmp/test\ 2.org

--- a/test/test-tags/test-custom-yaml.vim
+++ b/test/test-tags/test-custom-yaml.vim
@@ -4,7 +4,6 @@ runtime plugin/wiki.vim
 let g:wiki_log_verbose = 0
 
 let g:wiki_filetypes = ['md']
-let g:wiki_link_extension = '.md'
 let g:wiki_tag_parsers = [
       \ g:wiki#tags#default_parser,
       \ {

--- a/test/wiki-adoc/minimal.vim
+++ b/test/wiki-adoc/minimal.vim
@@ -1,7 +1,6 @@
 source ../init.vim
 syntax enable
 
-let g:wiki_link_target_type = 'adoc_xref_bracket'
 let g:wiki_filetypes = ['adoc']
 
 runtime plugin/wiki.vim


### PR DESCRIPTION
See the discussion in #296. This PR implements a first version of the proposed `g:wiki_link_creation`.

The new option provides a more flexible filetype-dependent behaviour. It deprecates four other options and makes configuring wiki.vim easier for most people. Since the new option provides sensible defaults, it also means most people will require less customization.

The following options are deprecated as the related features are all now _more flexibly_ controlled by `g:wiki_link_creation`:

* g:wiki_map_text_to_link
* g:wiki_map_create_page
* g:wiki_link_extension
* g:wiki_link_target_type