### PR TITLE
Allowing the creation or modification of Wiki{Pages,Tag,Toc}

### DIFF
--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -74,7 +74,7 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer -nargs=+ -complete=customlist,wiki#complete#tag_names
         \ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
-  command! -buffer WikiToc call g:wiki_select_methods.toc()
+  command! -buffer WikiToc call g:wiki_select_method.toc()
   command! -buffer -nargs=1 WikiClearCache call wiki#cache#clear(<q-args>)
 
   if b:wiki.in_journal

--- a/autoload/wiki/buffer.vim
+++ b/autoload/wiki/buffer.vim
@@ -74,11 +74,7 @@ function! s:init_buffer_commands() abort " {{{1
   command! -buffer -nargs=+ -complete=customlist,wiki#complete#tag_names
         \ WikiTagRename call wiki#tags#rename_ask(<f-args>)
 
-  if has('nvim') && g:wiki_select_method == 'ui_select'
-    command! -buffer WikiToc lua require('wiki').toc()
-  else
-    command! -buffer WikiToc call wiki#fzf#toc()
-  endif
+  command! -buffer WikiToc call g:wiki_select_methods.toc()
   command! -buffer -nargs=1 WikiClearCache call wiki#cache#clear(<q-args>)
 
   if b:wiki.in_journal

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -706,119 +706,119 @@ The AsciiDoc link macro [0] is a generic link syntax that looks like this: >
 
   link:<target>[<attrlist>]
 
-The `[<attrlist>]` will be recognized by `wiki.vim` as the link text.
+  The `[<attrlist>]` will be recognized by `wiki.vim` as the link text.
 
-[0]: https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/
+  [0]: https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/
 
-Cite links ~
-                                                               *wiki-link-cite*
-The cite links are a convenient link type that can be used with e.g. Zotero
-URLs. That is, instead of writing a link with URL `zot:citekey` one may simply
-write `@citekey`.
+  Cite links ~
+  *wiki-link-cite*
+  The cite links are a convenient link type that can be used with e.g. Zotero
+  URLs. That is, instead of writing a link with URL `zot:citekey` one may simply
+  write `@citekey`.
 
-See also |wiki-link-url| for more info on the Zotero URL scheme and handler.
+  See also |wiki-link-url| for more info on the Zotero URL scheme and handler.
 
-Iso dates ~
-                                                               *wiki-link-date*
-Dates written in ISO date format, e.g. 2023-05-05, will be recognized as
-a link to `journal:2023-05-05`.
+  Iso dates ~
+  *wiki-link-date*
+  Dates written in ISO date format, e.g. 2023-05-05, will be recognized as
+  a link to `journal:2023-05-05`.
 
-==============================================================================
-OPTIONS                                                          *wiki-options*
+  ==============================================================================
+  OPTIONS                                                          *wiki-options*
 
-`wiki.vim` has several options to configure the behaviour. The following is
-a reference of all available options.
+  `wiki.vim` has several options to configure the behaviour. The following is
+  a reference of all available options.
 
-*g:wiki_cache_root*
+  *g:wiki_cache_root*
   Specify the cache directory for `wiki.vim`.
 
   Default value: OS dependent
 
-    `Linux and MacOS`: `'~/.cache/wiki.vim/'`
-    `Windows`:         Standard temporary folder (based on |tempname()|)
+  `Linux and MacOS`: `'~/.cache/wiki.vim/'`
+  `Windows`:         Standard temporary folder (based on |tempname()|)
 
-*g:wiki_cache_persistent*
+  *g:wiki_cache_persistent*
   Specify whether to use persistent caching.
 
   Default value: 1
 
-*g:wiki_completion_enabled*
+  *g:wiki_completion_enabled*
   Specify whether to override 'omnifunc' when entering a wiki buffer. Set this
   to 0 if you want to use another omnifunc.
 
   Default value: 1
 
-*g:wiki_completion_case_sensitive*
+  *g:wiki_completion_case_sensitive*
   Specify whether to use case-sensitive matching for omnicompletion of links
   and tags.
 
   Default value: 1
 
-*g:wiki_export*
+  *g:wiki_export*
   A dictionary that specifies the default configuration for |WikiExport|
   options. See the specifications for the options for more information.
 
   Default: >vim
 
-    let g:wiki_export = {
-          \ 'args' : '',
-          \ 'from_format' : 'markdown',
-          \ 'ext' : 'pdf',
-          \ 'link_ext_replace': v:false,
-          \ 'view' : v:false,
-          \ 'output': fnamemodify(tempname(), ':h'),
-          \}
+  let g:wiki_export = {
+    \ 'args' : '',
+    \ 'from_format' : 'markdown',
+    \ 'ext' : 'pdf',
+    \ 'link_ext_replace': v:false,
+    \ 'view' : v:false,
+    \ 'output': fnamemodify(tempname(), ':h'),
+    \}
 
-*g:wiki_filetypes*
-  List of filetype extensions for which `wiki.vim` should be enabled. Notice
-  that file extensions are not always the same as the filetype. For example,
-  the common extension for Markdown is `.md`, whereas the filetype is called
-  `markdown`. The option should list the file extensions.
+  *g:wiki_filetypes*
+    List of filetype extensions for which `wiki.vim` should be enabled. Notice
+    that file extensions are not always the same as the filetype. For example,
+         the common extension for Markdown is `.md`, whereas the filetype is called
+           `markdown`. The option should list the file extensions.
 
-  The first element of the list is considered the default filetype where that
-  is relevant.
+           The first element of the list is considered the default filetype where that
+           is relevant.
 
-  Default: `['md']`
+           Default: `['md']`
 
-*g:wiki_fzf_pages_force_create_key*
-  Key combination that, when pressed while searching with |WikiPages|, will
-  create a new page with the name of the query. The value must be a string
-  recognized by fzf's `--expect` argument; see fzf's manual page for a list of
-  available keys.
+           *g:wiki_fzf_pages_force_create_key*
+           Key combination that, when pressed while searching with |WikiPages|, will
+           create a new page with the name of the query. The value must be a string
+           recognized by fzf's `--expect` argument; see fzf's manual page for a list of
+           available keys.
 
-  Default: `'alt-enter'`
+           Default: `'alt-enter'`
 
-*g:wiki_fzf_pages_opts*
-  A string with additional user options for |WikiPages|. This can be used
-  e.g. to add a previewer. Users should be aware that the page candidates are
-  "prettified" with the `--with-nth=1` and `-d` options for fzf, so to obtain
-  the page path in a previewer option one must use the field index expression `1`.
-  E.g.: >vim
+           *g:wiki_fzf_pages_opts*
+           A string with additional user options for |WikiPages|. This can be used
+           e.g. to add a previewer. Users should be aware that the page candidates are
+           "prettified" with the `--with-nth=1` and `-d` options for fzf, so to obtain
+           the page path in a previewer option one must use the field index expression `1`.
+           E.g.: >vim
 
-    let g:wiki_fzf_pages_opts = '--preview "cat {1}"'
-<
-  Default: `''`
+           let g:wiki_fzf_pages_opts = '--preview "cat {1}"'
+           <
+           Default: `''`
 
-*g:wiki_fzf_tags_opts*
-  A string with additional user options for |WikiTags|. This can be used
-  e.g. to add a previewer. Users should be aware that the page candidates are
-  "prettified" with the `-d` option for fzf, so to obtain the page path in a
-  previewer option one must use the field index expression `2..`.
-  E.g.: >vim
+           *g:wiki_fzf_tags_opts*
+           A string with additional user options for |WikiTags|. This can be used
+           e.g. to add a previewer. Users should be aware that the page candidates are
+           "prettified" with the `-d` option for fzf, so to obtain the page path in a
+           previewer option one must use the field index expression `2..`.
+           E.g.: >vim
 
-    let g:wiki_fzf_tags_opts = '--preview "bat --color=always {2..}"'
-<
-  Default: `''`
+           let g:wiki_fzf_tags_opts = '--preview "bat --color=always {2..}"'
+           <
+           Default: `''`
 
-*g:wiki_global_load*
-  `wiki.vim` is inherently agnostic in that it assumes any recognized filetype
-  specifies a wiki. However, some people might want to load `wiki.vim` for
-  ONLY files within a globally specified directory |g:wiki_root|. To allow
-  this behaviour, one can set this option to 0.
+           *g:wiki_global_load*
+           `wiki.vim` is inherently agnostic in that it assumes any recognized filetype
+           specifies a wiki. However, some people might want to load `wiki.vim` for
+           ONLY files within a globally specified directory |g:wiki_root|. To allow
+           this behaviour, one can set this option to 0.
 
-  Default: 1
+           Default: 1
 
-*g:wiki_select_method*
+           *g:wiki_select_method*
   A dictionary of functions that lets allow the user to choose his preferred
   the behaviour for the builtin commands: |WikiPage|, |WikiTags| and
   |WikiToc|.
@@ -854,6 +854,10 @@ a reference of all available options.
       - `require("wiki.ui_select").pages()`
       - `require("wiki.ui_select").tags()`
       - `require("wiki.ui_select").toc()`
+    - Telescope (https://github.com/nvim-telescope/telescope.nvim)
+      - `require("wiki.telescope").pages()
+      - `require("wiki.telescope").tags()
+      - `require("wiki.telescope").toc()
 
   Default (neovim): >lua
 

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -825,7 +825,7 @@ The AsciiDoc link macro [0] is a generic link syntax that looks like this: >
 
   This allows the user quite a lot of flexibility in specifying how which
   command will behave by letting him deciding wich builtin function use or
-  let him create one himself (see |wiki).
+  let him create one himself (see |wiki-advanced-config-3|).
 
   The following table shows the option keys and the related commands:
 
@@ -2306,13 +2306,81 @@ to be unencoded, then you could do something like this: >vim
 
 Example 3: Customize the `wiki` select method ~
                                                        *wiki-advanced-config-3*
->lua
+We support officially: Telescope, vim.ui.select and fzf.vim. But, if you want,
+you can use watever fuzzy finder you want. The following is a setup using
+`fzf-lua`: >lua
 
-  -- Using fzf-lua instead of ui-select for WikiPages
+  local fzf = require "fzf-lua"
+  local fzf_data = require "fzf-lua".config.__resume_data
+
+  local function fzf_pages()
+    fzf.files({
+      prompt = "Wiki files>",
+      cwd = vim.g.wiki_root,
+      actions = {
+        ['default'] = function(selected)
+          local note = selected[1]
+          if not note then
+            if not data.last_query then
+              return
+            end
+            note = data.last_query
+          end
+          vim.fn["wiki#page#open"](note)
+        end,
+      }
+    })
+  end
+
+  local function fzf_tags()
+    local tags_with_locations = vim.fn["wiki#tags#get_all"]()
+    local root = vim.fn["wiki#get_root"]()
+    local items = {}
+    for tag, locations in pairs(tags_with_locations) do
+      for _, loc in pairs(locations) do
+        local path = vim.fn["wiki#paths#relative"](loc[1], root)
+        local str = string.format("%s:%d:%s", tag, loc[2], path)
+        table.insert(items, str)
+      end
+    end
+    fzf.fzf_exec(items, {
+      actions = {
+        ['default'] = function(selected)
+          local note = vim.split(selected[1], ':')[3]
+          if not note then
+            return
+          end
+          vim.fn["wiki#page#open"](note)
+        end
+      }
+    })
+  end
+
+  local function fzf_toc()
+    local toc = vim.fn["wiki#toc#gather_entries"]()
+    local items = {}
+    for _, hd in pairs(toc) do
+      local indent = vim.fn["repeat"](".", hd.level - 1)
+      local line = indent .. hd.header
+      table.insert(items, string.format("%d:%s", hd.lnum, line))
+    end
+    fzf.fzf_exec(items, {
+      actions = {
+        ['default'] = function(selected)
+          local ln = vim.split(selected[1], ':')[1]
+          if not ln then
+            return
+          end
+          vim.fn.execute(ln)
+        end
+      }
+    })
+  end
+
   vim.g.wiki_select_method = {
-    pages = function()
-      require'fzf-lua'.files({ cwd = vim.g.wiki_root })
-    end,
+    pages = fzf_pages,
+    tags = fzf_tags,
+    toc = fzf_toc,
   }
 
 ==============================================================================

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -819,23 +819,58 @@ a reference of all available options.
   Default: 1
 
 *g:wiki_select_method*
-  A string to represent the UI select method used for the following commands:
+  A dictionary of functions that lets allow the user to choose his preferred
+  the behaviour for the builtin commands: |WikiPage|, |WikiTags| and
+  |WikiToc|.
 
-    - |WikiPages|
-    - |WikiTags|
-    - |WikiToc|
+  This allows the user quite a lot of flexibility in specifying how which
+  command will behave by letting him deciding wich builtin function use or
+  let him create one himself (see |wiki).
 
-  Possible values:
+  The following table shows the option keys and the related commands:
 
-    - `'ui_select'`  Use |vim.ui.select| (neovim only!)
-    - `'fzf'`        Use fzf (https://github.com/junegunn/fzf.vim). This has
-                   a few additional options for more fine tuned control:
-                   - |g:wiki_fzf_pages_opts|
-                   - |g:wiki_fzf_tags_opts|
-                   - |g:wiki_fzf_pages_force_create_key|
+    key     command
+    ---     -------
+    `pages` |WikiPages|
+    `tags`  |WikiTags|
+    `toc`   |WikiToc|
 
-  Default (neovim): `'ui_select'`
-  Default (Vim):    `'fzf'`
+  The dictionary values can be one of two types:
+
+    - |String|: The name of a function to be executed;
+    - |Funcref|: A function that will be executed.
+
+  The following builtin alternatives can be used:
+
+    - fzf (https://github.com/junegunn/fzf.vim):
+      - `wiki#fzf#pages()`
+      - `wiki#fzf#tags()`
+      - `wiki#fzf#toc()`
+      - Note: This has a few additional options for more fine tuned control:
+        - |g:wiki_fzf_pages_opts|
+        - |g:wiki_fzf_tags_opts|
+        - |g:wiki_fzf_pages_force_create_key|
+    - Lua backend that uses |vim.ui.select| (neovim only!)
+      - `require("wiki.ui_select").pages()`
+      - `require("wiki.ui_select").tags()`
+      - `require("wiki.ui_select").toc()`
+
+  Default (neovim): >lua
+
+    vim.g.wiki_select_method = {
+      pages = require("wiki.ui_select").pages,
+      tags = 'equire("wiki.ui_select").tags,
+      toc = require("wiki.ui_select").toc,
+    }
+<
+  Default (Vim): >vim
+
+    let g:wiki_select_method = {
+          \ 'pages': 'wiki#fzf#pages',
+          \ 'tags': 'wiki#fzf#tags',
+          \ 'toc': 'wiki#fzf#toc',
+          \}
+<
 
 *g:wiki_index_name*
   A string with the index page name for the wiki. The value should not include
@@ -2264,6 +2299,17 @@ to be unencoded, then you could do something like this: >vim
         \   'url_transform': { x -> wiki#url#utils#url_encode(x) },
         \ },
         \}
+
+Example 3: Customize the `wiki` select method ~
+                                                       *wiki-advanced-config-3*
+>lua
+
+  -- Using fzf-lua instead of ui-select for WikiPages
+  vim.g.wiki_select_method = {
+    pages = function()
+      require'fzf-lua'.files({ cwd = vim.g.wiki_root })
+    end,
+  }
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:fdm=marker:cole=2:

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -2321,10 +2321,9 @@ you can use watever fuzzy finder you want. The following is a setup using
         ['default'] = function(selected)
           local note = selected[1]
           if not note then
-            if not data.last_query then
-              return
+            if fzf_data.last_query then
+              note = fzf_data.last_query
             end
-            note = data.last_query
           end
           vim.fn["wiki#page#open"](note)
         end,
@@ -2347,10 +2346,9 @@ you can use watever fuzzy finder you want. The following is a setup using
       actions = {
         ['default'] = function(selected)
           local note = vim.split(selected[1], ':')[3]
-          if not note then
-            return
+          if note then
+            vim.fn["wiki#page#open"](note)
           end
-          vim.fn["wiki#page#open"](note)
         end
       }
     })
@@ -2368,10 +2366,9 @@ you can use watever fuzzy finder you want. The following is a setup using
       actions = {
         ['default'] = function(selected)
           local ln = vim.split(selected[1], ':')[1]
-          if not ln then
-            return
+          if ln then
+            vim.fn.execute(ln)
           end
-          vim.fn.execute(ln)
         end
       }
     })

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -706,119 +706,119 @@ The AsciiDoc link macro [0] is a generic link syntax that looks like this: >
 
   link:<target>[<attrlist>]
 
-  The `[<attrlist>]` will be recognized by `wiki.vim` as the link text.
+The `[<attrlist>]` will be recognized by `wiki.vim` as the link text.
 
-  [0]: https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/
+[0]: https://docs.asciidoctor.org/asciidoc/latest/macros/link-macro/
 
-  Cite links ~
-  *wiki-link-cite*
-  The cite links are a convenient link type that can be used with e.g. Zotero
-  URLs. That is, instead of writing a link with URL `zot:citekey` one may simply
-  write `@citekey`.
+Cite links ~
+                                                               *wiki-link-cite*
+The cite links are a convenient link type that can be used with e.g. Zotero
+URLs. That is, instead of writing a link with URL `zot:citekey` one may simply
+write `@citekey`.
 
-  See also |wiki-link-url| for more info on the Zotero URL scheme and handler.
+See also |wiki-link-url| for more info on the Zotero URL scheme and handler.
 
-  Iso dates ~
-  *wiki-link-date*
-  Dates written in ISO date format, e.g. 2023-05-05, will be recognized as
-  a link to `journal:2023-05-05`.
+Iso dates ~
+                                                               *wiki-link-date*
+Dates written in ISO date format, e.g. 2023-05-05, will be recognized as
+a link to `journal:2023-05-05`.
 
-  ==============================================================================
-  OPTIONS                                                          *wiki-options*
+==============================================================================
+OPTIONS                                                          *wiki-options*
 
-  `wiki.vim` has several options to configure the behaviour. The following is
-  a reference of all available options.
+`wiki.vim` has several options to configure the behaviour. The following is
+a reference of all available options.
 
-  *g:wiki_cache_root*
+*g:wiki_cache_root*
   Specify the cache directory for `wiki.vim`.
 
   Default value: OS dependent
 
-  `Linux and MacOS`: `'~/.cache/wiki.vim/'`
-  `Windows`:         Standard temporary folder (based on |tempname()|)
+    `Linux and MacOS`: `'~/.cache/wiki.vim/'`
+    `Windows`:         Standard temporary folder (based on |tempname()|)
 
-  *g:wiki_cache_persistent*
+*g:wiki_cache_persistent*
   Specify whether to use persistent caching.
 
   Default value: 1
 
-  *g:wiki_completion_enabled*
+*g:wiki_completion_enabled*
   Specify whether to override 'omnifunc' when entering a wiki buffer. Set this
   to 0 if you want to use another omnifunc.
 
   Default value: 1
 
-  *g:wiki_completion_case_sensitive*
+*g:wiki_completion_case_sensitive*
   Specify whether to use case-sensitive matching for omnicompletion of links
   and tags.
 
   Default value: 1
 
-  *g:wiki_export*
+*g:wiki_export*
   A dictionary that specifies the default configuration for |WikiExport|
   options. See the specifications for the options for more information.
 
   Default: >vim
 
-  let g:wiki_export = {
-    \ 'args' : '',
-    \ 'from_format' : 'markdown',
-    \ 'ext' : 'pdf',
-    \ 'link_ext_replace': v:false,
-    \ 'view' : v:false,
-    \ 'output': fnamemodify(tempname(), ':h'),
-    \}
+    let g:wiki_export = {
+          \ 'args' : '',
+          \ 'from_format' : 'markdown',
+          \ 'ext' : 'pdf',
+          \ 'link_ext_replace': v:false,
+          \ 'view' : v:false,
+          \ 'output': fnamemodify(tempname(), ':h'),
+          \}
 
-  *g:wiki_filetypes*
-    List of filetype extensions for which `wiki.vim` should be enabled. Notice
-    that file extensions are not always the same as the filetype. For example,
-         the common extension for Markdown is `.md`, whereas the filetype is called
-           `markdown`. The option should list the file extensions.
+*g:wiki_filetypes*
+  List of filetype extensions for which `wiki.vim` should be enabled. Notice
+  that file extensions are not always the same as the filetype. For example,
+  the common extension for Markdown is `.md`, whereas the filetype is called
+  `markdown`. The option should list the file extensions.
 
-           The first element of the list is considered the default filetype where that
-           is relevant.
+  The first element of the list is considered the default filetype where that
+  is relevant.
 
-           Default: `['md']`
+  Default: `['md']`
 
-           *g:wiki_fzf_pages_force_create_key*
-           Key combination that, when pressed while searching with |WikiPages|, will
-           create a new page with the name of the query. The value must be a string
-           recognized by fzf's `--expect` argument; see fzf's manual page for a list of
-           available keys.
+*g:wiki_fzf_pages_force_create_key*
+  Key combination that, when pressed while searching with |WikiPages|, will
+  create a new page with the name of the query. The value must be a string
+  recognized by fzf's `--expect` argument; see fzf's manual page for a list of
+  available keys.
 
-           Default: `'alt-enter'`
+  Default: `'alt-enter'`
 
-           *g:wiki_fzf_pages_opts*
-           A string with additional user options for |WikiPages|. This can be used
-           e.g. to add a previewer. Users should be aware that the page candidates are
-           "prettified" with the `--with-nth=1` and `-d` options for fzf, so to obtain
-           the page path in a previewer option one must use the field index expression `1`.
-           E.g.: >vim
+*g:wiki_fzf_pages_opts*
+  A string with additional user options for |WikiPages|. This can be used
+  e.g. to add a previewer. Users should be aware that the page candidates are
+  "prettified" with the `--with-nth=1` and `-d` options for fzf, so to obtain
+  the page path in a previewer option one must use the field index expression `1`.
+  E.g.: >vim
 
-           let g:wiki_fzf_pages_opts = '--preview "cat {1}"'
-           <
-           Default: `''`
+    let g:wiki_fzf_pages_opts = '--preview "cat {1}"'
+<
+  Default: `''`
 
-           *g:wiki_fzf_tags_opts*
-           A string with additional user options for |WikiTags|. This can be used
-           e.g. to add a previewer. Users should be aware that the page candidates are
-           "prettified" with the `-d` option for fzf, so to obtain the page path in a
-           previewer option one must use the field index expression `2..`.
-           E.g.: >vim
+*g:wiki_fzf_tags_opts*
+  A string with additional user options for |WikiTags|. This can be used
+  e.g. to add a previewer. Users should be aware that the page candidates are
+  "prettified" with the `-d` option for fzf, so to obtain the page path in a
+  previewer option one must use the field index expression `2..`.
+  E.g.: >vim
 
-           let g:wiki_fzf_tags_opts = '--preview "bat --color=always {2..}"'
-           <
-           Default: `''`
+    let g:wiki_fzf_tags_opts = '--preview "bat --color=always {2..}"'
+<
+  Default: `''`
 
-           *g:wiki_global_load*
-           `wiki.vim` is inherently agnostic in that it assumes any recognized filetype
-           specifies a wiki. However, some people might want to load `wiki.vim` for
-           ONLY files within a globally specified directory |g:wiki_root|. To allow
-           this behaviour, one can set this option to 0.
+*g:wiki_global_load*
+  `wiki.vim` is inherently agnostic in that it assumes any recognized filetype
+  specifies a wiki. However, some people might want to load `wiki.vim` for
+  ONLY files within a globally specified directory |g:wiki_root|. To allow
+  this behaviour, one can set this option to 0.
 
-           Default: 1
+  Default: 1
 
-           *g:wiki_select_method*
+*g:wiki_select_method*
   A dictionary of functions that lets allow the user to choose his preferred
   the behaviour for the builtin commands: |WikiPage|, |WikiTags| and
   |WikiToc|.

--- a/lua/wiki/telescope.lua
+++ b/lua/wiki/telescope.lua
@@ -1,0 +1,120 @@
+local conf = require("telescope.config").values
+local pickers = require "telescope.pickers"
+local finders = require "telescope.finders"
+local builtin = require "telescope.builtin"
+local actions = require "telescope.actions"
+local action_state = require "telescope.actions.state"
+local M = {}
+
+function M.pages(opts)
+  builtin.find_files(vim.tbl_deep_extend("force", {
+    prompt_title = "Wiki files",
+    cwd = vim.g.wiki_root,
+    file_ignore_patterns = {
+      "%.stversions/",
+      "%.git/",
+    },
+    path_display = function(_, path)
+      local name = path:match "(.+)%.[^.]+$"
+      return name or path
+    end,
+    attach_mappings = function(prompt_bufnr, _)
+      actions.select_default:replace_if(function()
+        return action_state.get_selected_entry() == nil
+      end, function()
+        actions.close(prompt_bufnr)
+        local new_name = action_state.get_current_line()
+        if vim.fn.empty(new_name) ~= 1 then
+          return
+        end
+        vim.fn["wiki#page#open"](new_name)
+      end)
+      return true
+    end,
+  }, opts or {}))
+end
+
+function M.tags(opts)
+  local tags_with_locations = vim.fn["wiki#tags#get_all"]()
+
+  local length = 0
+  for tag, _ in pairs(tags_with_locations) do
+    if #tag > length then
+      length = #tag
+    end
+  end
+
+  local root = vim.fn["wiki#get_root"]()
+  local items = {}
+  for tag, locations in pairs(tags_with_locations) do
+    for _, loc in pairs(locations) do
+      local path_rel = vim.fn["wiki#paths#relative"](loc[1], root)
+      local str = string.format("%-" .. length .. "s  %s:%s", tag, path_rel, loc[2])
+      table.insert(items, { str, loc[1], loc[2] })
+    end
+  end
+
+  opts = opts or {}
+
+  local telescope_opts = vim.tbl_deep_extend("force", {
+    prompt_title = "Wiki Tags",
+    sorter       = conf.generic_sorter(opts),
+    previewer    = conf.grep_previewer(opts),
+  }, opts)
+
+  pickers.new(telescope_opts, {
+    finder = finders.new_table {
+      results = items,
+      entry_maker = function(entry)
+        return {
+          value = entry[2],
+          display = entry[1],
+          ordinal = entry[1],
+          lnum = entry[3],
+        }
+      end
+    },
+  }):find()
+end
+
+function M.toc(opts)
+  local toc = vim.fn["wiki#toc#gather_entries"]()
+
+  local items = {}
+  for _, hd in pairs(toc) do
+    local indent = vim.fn["repeat"](".", hd.level - 1)
+    local line = indent .. hd.header
+    table.insert(items, { line, hd.lnum })
+  end
+
+  opts = opts or {}
+
+  local telescope_opts = vim.tbl_deep_extend("force", {
+    prompt_title = "Wiki Toc",
+    sorter       = conf.generic_sorter(opts),
+    previewer    = false,
+  }, opts)
+
+  pickers.new(telescope_opts, {
+    finder = finders.new_table {
+      results = items,
+      entry_maker = function(entry)
+        return {
+          value = entry[2],
+          display = entry[1],
+          ordinal = entry[1],
+          lnum = entry[2],
+        }
+      end,
+      attach_mappings = function(prompt_buf, _)
+        actions.select_default:replace(function()
+          actions.close(prompt_buf)
+          local entry = action_state.get_selected_entry()
+          vim.cmd.execute(entry)
+        end)
+      end
+    },
+  }):find()
+end
+
+return M

--- a/lua/wiki/ui_select.lua
+++ b/lua/wiki/ui_select.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.get_pages()
+function M.pages()
   -- wiki#page#get_all returns a list of path pairs, where the first element is
   -- the absolute path and the second element is the path relative to wiki
   -- root.
@@ -20,7 +20,7 @@ function M.get_pages()
   end)
 end
 
-function M.get_tags()
+function M.tags()
   local tags_with_locations = vim.fn["wiki#tags#get_all"]()
 
   local length = 0

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -161,6 +161,10 @@ let s:mappings = index(['all', 'global'], g:wiki_mappings_use_defaults) >= 0
 call extend(s:mappings, get(g:, 'wiki_mappings_global', {}))
 call wiki#init#apply_mappings_from_dict(s:mappings, '')
 
+if type(g:wiki_select_method) == 1
+  echoerr 'Deprecation notice: wiki_select_method wants different arguments, see :h wiki_select_method to learn more'
+endif
+
 " Enable on desired filetypes
 augroup wiki
   autocmd!

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -94,14 +94,14 @@ call wiki#init#option('wiki_template_month_names', [
 call wiki#init#option('wiki_root', '')
 if has('nvim')
 lua << EOF
-  vim.fn['wiki#init#option']('wiki_select_methods', {
+  vim.fn['wiki#init#option']('wiki_select_method', {
     pages = require("wiki.ui_select").pages,
     tags = require("wiki.ui_select").tags,
     toc = require("wiki.ui_select").toc,
   })
 EOF
 else
-  call wiki#init#option('wiki_select_methods', {
+  call wiki#init#option('wiki_select_method', {
         \ 'pages': 'wiki#wiki#fzf#pages',
         \ 'tags': 'wiki#wiki#fzf#tags',
         \ 'toc': 'wiki#wiki#fzf#toc',
@@ -140,8 +140,8 @@ command!          WikiIndex   call wiki#goto_index()
 command! -nargs=? WikiOpen    call wiki#page#open(<f-args>)
 command!          WikiReload  call wiki#reload()
 command!          WikiJournal call wiki#journal#open()
-command!          WikiPages   call g:wiki_select_methods.pages()
-command!          WikiTags    call g:wiki_select_methods.tags()
+command!          WikiPages   call g:wiki_select_method.pages()
+command!          WikiTags    call g:wiki_select_method.tags()
 " Initialize mappings
 nnoremap <silent> <plug>(wiki-index)     :WikiIndex<cr>
 nnoremap <silent> <plug>(wiki-open)      :WikiOpen<cr>

--- a/plugin/wiki.vim
+++ b/plugin/wiki.vim
@@ -93,9 +93,19 @@ call wiki#init#option('wiki_template_month_names', [
       \])
 call wiki#init#option('wiki_root', '')
 if has('nvim')
-  call wiki#init#option('wiki_select_method', 'ui_select')
+lua << EOF
+  vim.fn['wiki#init#option']('wiki_select_methods', {
+    pages = require("wiki.ui_select").pages,
+    tags = require("wiki.ui_select").tags,
+    toc = require("wiki.ui_select").toc,
+  })
+EOF
 else
-  call wiki#init#option('wiki_select_method', 'fzf')
+  call wiki#init#option('wiki_select_methods', {
+        \ 'pages': 'wiki#wiki#fzf#pages',
+        \ 'tags': 'wiki#wiki#fzf#tags',
+        \ 'toc': 'wiki#wiki#fzf#toc',
+        \})
 endif
 call wiki#init#option('wiki_tag_list', { 'output' : 'loclist' })
 call wiki#init#option('wiki_tag_search', { 'output' : 'loclist' })
@@ -130,14 +140,8 @@ command!          WikiIndex   call wiki#goto_index()
 command! -nargs=? WikiOpen    call wiki#page#open(<f-args>)
 command!          WikiReload  call wiki#reload()
 command!          WikiJournal call wiki#journal#open()
-if has('nvim') && g:wiki_select_method == 'ui_select'
-  command! WikiPages lua require('wiki').get_pages()
-  command! WikiTags lua require('wiki').get_tags()
-else
-  command! WikiPages call wiki#fzf#pages()
-  command! WikiTags call wiki#fzf#tags()
-endif
-
+command!          WikiPages   call g:wiki_select_methods.pages()
+command!          WikiTags    call g:wiki_select_methods.tags()
 " Initialize mappings
 nnoremap <silent> <plug>(wiki-index)     :WikiIndex<cr>
 nnoremap <silent> <plug>(wiki-open)      :WikiOpen<cr>


### PR DESCRIPTION
Hi @lervag I'm back :),
When I first implemented the `vim.ui.select` (#281) backed for the `Wiki{Pages,Tag,Toc}`, I've overestimated the usefulness of this implementation. The function is very primitive and doesn't let you do anything that I will consider useful for searching my note (e.g. inability to open split from selected item and the lack of a preview).

For this reason I'm very confident very few are actually using the feature.

So since I think that adding every support for every fuzzy finder is not viable, and even if it was, we still could not represent the needs of all users, I've been thinking of an interface where people can overwrite/write the different backends for this commands. This can have the following benefits:
* Removing existing `wiki_fzf_pages_opts` and `wiki_fzf_tags_opts`, since the user will be able to simply overwrite the fzf backend;
* Make possible to keep this commands without creating new ones;
* Opens possibility for create plugins to add support for other backends and uis.

This implementation is very hacked toghether and very awkward to use both in lua and vimscript (need your infinite vimL knowledge to figure out a way to do it that makes sense). 