### PR TITLE
doc: add link.vim

### DIFF
--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -409,6 +409,11 @@ journal or diary in `wiki.vim`: >vim
           \ :<c-u>call wiki#journal#open()<cr>
   augroup END
 
+link.vim ~
+https://github.com/qadzek/link.vim
+A plugin for managing long URLs. It converts inline Markdown links to
+reference-style links, to keep them out of your way.
+
 ------------------------------------------------------------------------------
 ALTERNATIVES                                          *wiki-intro-alternatives*
 


### PR DESCRIPTION
Currently, I am a Vimwiki user, but I like the "do one thing and do it well" philosophy. I might give your plugin a try in the future, as the Vimwiki project seems a bit abandoned.

I developed [link.vim](https://github.com/qadzek/link.vim) for Vimwiki, but it might also be useful for `wiki.vim`, at least for users using Markdown syntax and Markdown links.

After briefly installing your plugin, everything seems to work as expected. `:help wiki-link-reference` also confirms that reference-style links are supported.