### PR TITLE
doc: fix key bindings to navigate journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please also read the `Guide` section in the [documentation](doc/wiki.txt).
     - `it at` Link text
   - New page templates
 - Support for journal entries
-  - Navigating the journal back and forth with `<c-j>` and `<c-k>`
+  - Navigating the journal back and forth with `<c-p>` and `<c-n>`
   - Support for parsing journal entries in order to make weekly and monthly
     summaries. The parsed result needs manual editing for good results.
 - Utility functionality


### PR DESCRIPTION
According to the help file, this should be `<C-p>` and `<C-n>`. I tried it, and that indeed seems to be the case.