### PR TITLE
Update nvim.vim for wiki#link#incoming_hover to work on nvim 0.7.2

### DIFF
--- a/autoload/wiki/ui/nvim.vim
+++ b/autoload/wiki/ui/nvim.vim
@@ -184,7 +184,7 @@ function! wiki#ui#nvim#popup(cfg) abort " {{{1
   " Create and fill the buffer
   let l:bufnr = nvim_create_buf(v:false, v:true)
   call nvim_buf_set_lines(l:bufnr, 0, -1, v:false, l:content)
-  call nvim_set_option_value('buftype', 'nofile', #{ buf: l:bufnr })
+  call nvim_buf_set_option(l:bufnr, 'buftype', 'nofile')
 
   " Create popup window
   let l:winopts = #{
@@ -211,7 +211,7 @@ function! wiki#ui#nvim#popup(cfg) abort " {{{1
     let l:winopts.col = (l:winwidth - l:width)/2
   endif
   let l:winid = nvim_open_win(l:bufnr, v:true, l:winopts)
-  call nvim_set_option_value('foldenable', v:false, #{ win: l:winid })
+  call nvim_win_set_option(l:winid, 'foldenable', v:false)
   if l:popup.hide_cursor
     let l:popup._guicursor = &guicursor
     let &guicursor = 'a:WikiHideCursor'


### PR DESCRIPTION
Hi lervag!

A long time ago I suggested a feature that you implemented in the `WikiLinkIncomingHover` function. Since I had actually forked your repo before the last release you made, I am just now starting to use it, and it is awesome now that I made it work on **nvim 0.7.2**.

I solved an error when **calling the function on a header that has incoming links** (which i can tell by calling `WikiClearCache links-in` and `WikiLinkIncomingToggle`):

```
Error detected while processing function wiki#link#incoming_hover[13]..wiki#ui#select[13]..wiki#ui#nvim#select[30]..wiki#ui#nvim#popup: line 49:
E5555: API call: Invalid key: 'buf'
Error detected while processing function wiki#link#incoming_hover[13]..wiki#ui#select: line 13:
E714: List required
```

After the changes, popup works as expected, but are you able to reproduce this error? nvim 0.7.2 is the newest version on Ubuntu's ppa, but it may still be older than the versions for which your original code applies. 