### PR TITLE
doc: adjust WikiExport documentation

### DIFF
--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -1960,8 +1960,8 @@ MAPPINGS AND COMMANDS REFERENCE                       *wiki-mappings-reference*
     in-browser wiki navigation, but for it to work well, it requires that:
 
       1. `-ext` is set to `html`, and
-      2. |g:wiki_link_creation| should have a `url_transform` that appends
-         the extension.
+      2. |g:wiki_link_creation| should have an entry with the key `html`,
+         which contains the option `url_extension` with the value `.html`.
 
   -output ~
     Set output directory where the exported file is stored. Relative paths are


### PR DESCRIPTION
Hey, 
it seems to be sufficient to set only `url_extension` to make `-link_ext_replace` work. It's my first pull request I ever made. So I appreciate every feedback. 