### PR TITLE
doc: Remove outdated text in g:wiki_templates

### DIFF
--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -1487,10 +1487,6 @@ a reference of all available options.
           \   'source_func': function('TemplateFallback')},
           \]
 <
-  Notice that in the second template, the `;` is appended to the source
-  filename. This means the template file is first searched for in the current
-  directory of the new page, then in the parent directory, and so on. If the
-  template file is not found, then the next template will be tried.
 
   Default: `[]`
 


### PR DESCRIPTION
After the example of `g:wiki_templates`  it is mentioned, that `;` is appended to the source filename. However,  I could not find `;` in the example above.  I assume this part of the doc is outdated. Thus, I suggest to remove this part in the doc. 