### PR TITLE
Improve fzf select

### DIFF
--- a/autoload/wiki/fzf.vim
+++ b/autoload/wiki/fzf.vim
@@ -19,7 +19,7 @@ function! wiki#fzf#pages() abort "{{{1
   call fzf#run(fzf#wrap({
         \ 'source': map(
         \   wiki#page#get_all(),
-        \   {_, x -> x[0] . '#####' . x[1] }),
+        \   {_, x -> x[0] . '#####' . substitute(x[1], '^/', '', '') }),
         \ 'sink*': funcref('s:accept_page'),
         \ 'options': l:fzf_opts
         \}))
@@ -97,7 +97,7 @@ function! wiki#fzf#links(...) abort "{{{1
   call fzf#run(fzf#wrap({
         \ 'source': map(
         \   wiki#page#get_all(),
-        \   {_, x -> x[0] .. '#####' .. l:mode .. '#####' .. x[1] }),
+        \   {_, x -> x[0] .. '#####' .. l:mode .. '#####' .. substitute(x[1], '^/', '', '') }),
         \ 'sink*': funcref('s:accept_link'),
         \ 'options': l:fzf_opts
         \}))

--- a/autoload/wiki/fzf.vim
+++ b/autoload/wiki/fzf.vim
@@ -12,7 +12,7 @@ function! wiki#fzf#pages() abort "{{{1
 
   let l:fzf_opts = join([
         \ '-d"#####" --with-nth=-1 --print-query --prompt "WikiPages> "',
-        \ '--expect=' . get(g:, 'wiki_fzf_pages_force_create_key', 'alt-enter'),
+        \ '--expect=' . get(g:, 'wiki_fzf_force_create_key', 'alt-enter'),
         \ g:wiki_fzf_pages_opts,
         \])
 
@@ -91,6 +91,7 @@ function! wiki#fzf#links(...) abort "{{{1
 
   let l:fzf_opts = join([
         \ '-d"#####" --with-nth=-1 --print-query --prompt "WikiLinkAdd> "',
+        \ '--expect=' . get(g:, 'wiki_fzf_force_create_key', 'alt-enter'),
         \ g:wiki_fzf_links_opts,
         \])
 
@@ -109,7 +110,7 @@ function! s:accept_page(lines) abort "{{{1
   " a:lines is a list with two or three elements. Two if there were no matches,
   " and three if there is one or more matching names. The first element is the
   " search query; the second is either an empty string or the alternative key
-  " specified by g:wiki_fzf_pages_force_create_key (e.g. 'alt-enter') if this
+  " specified by g:wiki_fzf_force_create_key (e.g. 'alt-enter') if this
   " was pressed; the third element contains the selected item.
   if len(a:lines) < 2 | return | endif
 
@@ -152,25 +153,31 @@ endfunction
 
 "}}}1
 function! s:accept_link_visual(lines) abort "{{{1
-  " a:lines is a list with one or two elements. Two if there was a match, else
-  " one. The first element is the search query; the second element contains the
-  " selected item.
+  " a:lines is a list with two or three elements. Two if there were no matches,
+  " and three if there is one or more matching names. The first element is the
+  " search query; the second is either an empty string or the alternative key
+  " specified by g:wiki_fzf_force_create_key (e.g. 'alt-enter') if this
+  " was pressed; the third element contains the selected item.
   let l:path = s:get_path(a:lines)
   call wiki#link#add(l:path, 'visual')
 endfunction
 
 " }}}1
 function! s:get_path(lines) abort "{{{1
-  return len(a:lines) == 2
-        \ ? split(a:lines[2], '#####')[0]
-        \ : a:lines[0]
+  if len(a:lines) == 2 || !empty(a:lines[1])
+    return a:lines[0]
+  else
+    return split(a:lines[2], '#####')[0]
+  endif
 endfunction
 
 " }}}1
 function! s:accept_link_insert(lines) abort "{{{1
-  " a:lines is a list with one or two elements. Two if there was a match, else
-  " one. The first element is the search query; the second element contains the
-  " selected item.
+  " a:lines is a list with two or three elements. Two if there were no matches,
+  " and three if there is one or more matching names. The first element is the
+  " search query; the second is either an empty string or the alternative key
+  " specified by g:wiki_fzf_force_create_key (e.g. 'alt-enter') if this
+  " was pressed; the third element contains the selected item.
   let l:path = s:get_path(a:lines)
   call wiki#link#add(l:path, 'insert')
   call feedkeys('a')
@@ -178,9 +185,11 @@ endfunction
 
 " }}}1
 function! s:accept_link_normal(lines) abort "{{{1
-  " a:lines is a list with one or two elements. Two if there was a match, else
-  " one. The first element is the search query; the second element contains the
-  " selected item.
+  " a:lines is a list with two or three elements. Two if there were no matches,
+  " and three if there is one or more matching names. The first element is the
+  " search query; the second is either an empty string or the alternative key
+  " specified by g:wiki_fzf_force_create_key (e.g. 'alt-enter') if this
+  " was pressed; the third element contains the selected item.
   let l:path = s:get_path(a:lines)
   call wiki#link#add(l:path, '')
 endfunction

--- a/doc/wiki.txt
+++ b/doc/wiki.txt
@@ -791,7 +791,7 @@ a reference of all available options.
 
   Default: `['md']`
 
-*g:wiki_fzf_pages_force_create_key*
+*g:wiki_fzf_force_create_key*
   Key combination that, when pressed while searching with |WikiPages|, will
   create a new page with the name of the query. The value must be a string
   recognized by fzf's `--expect` argument; see fzf's manual page for a list of
@@ -857,10 +857,11 @@ a reference of all available options.
 
     - fzf (https://github.com/junegunn/fzf.vim):
       - `wiki#fzf#pages`     |g:wiki_fzf_pages_opts|
-                           |g:wiki_fzf_pages_force_create_key|
+                           |g:wiki_fzf_force_create_key|
       - `wiki#fzf#tags`      |g:wiki_fzf_tags_opts|
       - `wiki#fzf#toc`
       - `wiki#fzf#links`     |g:wiki_fzf_links_opts|
+                           |g:wiki_fzf_force_create_key|
     - Lua backend that uses |vim.ui.select| (neovim only!)
       - `require("wiki.ui_select").pages`
       - `require("wiki.ui_select").tags`
@@ -1789,7 +1790,19 @@ MAPPINGS AND COMMANDS REFERENCE                       *wiki-mappings-reference*
 *WikiLinkAdd*
   List the wiki files in the current wiki. Select from the list to add a link
   to that target page. This uses the UI select method defined by
-  |g:wiki_select_method|. The mapping also works from insert mode.
+  |g:wiki_select_method|. The mapping also works from insert and visual mode.
+
+    fzf specific behaviour ~
+      If |g:wiki_select_method| is `'fzf'`, then it is possible to create
+      a new page by pressing |g:wiki_fzf_force_create_key| (alt-enter,
+      by default). That is, a link whose name is equal to the fzf query will
+      be created.
+
+      For convenience, if the input query does not have any results, simply
+      pressing enter will also create a page. E.g., if you searched for "My
+      Fzf Page", and this term does not exist, then it will instead create a
+      new link "My Fzf Page.wiki" (or similar, depending on the value of other
+      options).
 
 *<plug>(wiki-link-next)*
 *WikiLinkNext*
@@ -2032,7 +2045,7 @@ MAPPINGS AND COMMANDS REFERENCE                       *wiki-mappings-reference*
 
     fzf specific behaviour ~
       If |g:wiki_select_method| is `'fzf'`, then it is possible to create
-      a new page by pressing |g:wiki_fzf_pages_force_create_key| (alt-enter,
+      a new page by pressing |g:wiki_fzf_force_create_key| (alt-enter,
       by default). That is, a page whose name is equal to the fzf query will
       be created if it doesn't already exist. If the page exists, the existing
       page will be opened.

--- a/test/example-select-methods/select-methods-fzf.vim
+++ b/test/example-select-methods/select-methods-fzf.vim
@@ -13,6 +13,7 @@ syntax enable
 
 nnoremap q :qall!<cr>
 
+let mapleader=" "
 let g:wiki_cache_persistent = 0
 let g:wiki_filetypes = ['wiki']
 let g:wiki_root = '../wiki-basic'


### PR DESCRIPTION
Dear @lervag,
I suggest three improvements for `wiki#fzf#link` which also fixes a bug. I combined them in one pull request, because they depend on each other. 

1. The first commit removes `/` in the beginning of every search query in `wiki#fzf#pages` and `wiki#fzf#links`.
2. Unfortunately in the current state `wiki#fzf#link` does not work for new links, since the `mode` variable is incapsulated in existing pages. The second commit fixes this issue. 
3. The last commit adds a force key for `wiki#fzf#link` similar to the one of `wiki#fzf#pages`. It is worth mentioning that I changed `g:wiki_fzf_pages_force_create_key` to `g:wiki_fzf_force_create_key` to make it usable for both mentioned selecting methods. 

Best regards