### PR TITLE
fix: different leader key than the default in test

### DIFF
--- a/test/example-select-methods/select-methods-fzf.vim
+++ b/test/example-select-methods/select-methods-fzf.vim
@@ -13,7 +13,6 @@ syntax enable
 
 nnoremap q :qall!<cr>
 
-let mapleader=" "
 let g:wiki_cache_persistent = 0
 let g:wiki_filetypes = ['wiki']
 let g:wiki_root = '../wiki-basic'


### PR DESCRIPTION
In `select-methods-fzf.vim` I accidentally assigned a different value to `mapleader` than the default. This commit removes that line from the file. 