### PR TITLE
Remove mention of incorrect filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ This outlines the basic steps to get started:
    let g:wiki_root = '~/wiki'
    ```
 
-3. Now you can open the index file (by default `index.wiki`) with `<leader>ww`
-   and start to add your notes as desired.
+3. Now you can open the index file with `<leader>ww` and start to add your notes
+   as desired.
 
 Please also read the `Guide` section in the [documentation](doc/wiki.txt).
 


### PR DESCRIPTION
If the `wiki.vim` configuration consists solely of `let g:wiki_root = '~/wiki'`, hitting `<leader>ww` actually opens `index.md` instead of `index.wiki`. This behavior changes when `let g:wiki_filetypes = [ 'wiki' ]` is added to the configuration.

In the similar section in `:help wiki-intro-usage` no filename is mentioned, so I've updated `README.md` accordingly.