### PR TITLE
fix: trailing punctuation breaking bare URLs

### DIFF
--- a/autoload/wiki/rx.vim
+++ b/autoload/wiki/rx.vim
@@ -35,7 +35,7 @@ let wiki#rx#italic = wiki#rx#surrounded(
       \ '[^_`[:space:]]\%([^_`]*[^_`[:space:]]\)\?', '_')
 let wiki#rx#date = '\d\d\d\d-\d\d-\d\d'
 let wiki#rx#url =
-      \ '\%(\<\l\+:\%(\/\/\)\?[^ \t()\[\]|]\+'
+      \ '\%(\<\l\+:\%(\/\/\)\?[^ \t()\[\]|]\+[^ \t()\[\]|.,?!:;''"]'
       \ . '\|'
       \ . '<\zs\l\+:\%(\/\/\)\?[^>]\+\ze>\)'
 let wiki#rx#reftext = '[^\\\[\]]\{-}'


### PR DESCRIPTION
URLs would incorrectly include trailing punctuation such as .,?!:;"' when matching bare URLs, causing broken links.  Updated the regex to exclude these characters at the end.

---

Running `:WikiLinkFollow` on any of the following URLs leads the user to the wrong website, e.g. to `https://github.com!`.

```markdown
Visit GitHub at https://github.com. to view my repo.
Visit GitHub at https://github.com, to view my repo.
Visit GitHub at https://github.com? to view my repo.
Visit GitHub at https://github.com! to view my repo.
Visit GitHub at https://github.com: to view my repo.
Visit GitHub at https://github.com; to view my repo.
Visit GitHub at 'https://github.com' to view my repo.
Visit GitHub at "https://github.com" to view my repo.
```

One could consider these "bare" or "raw" URLs as improper usage, and use angled brackets like you suggested:

```markdown
Visit GitHub at <https://github.com>, to view my repo.
```

The alternative would be to change the regex.
A user of `link.vim` has reported this as a bug in the past: https://github.com/qadzek/link.vim/issues/12 
Some [manuals](https://www.chicagomanualofstyle.org/qanda/data/faq/topics/URLs/faq0007.html) recommend punctuation directly following a URL.

The downside of changing the regex is that this would also remove these characters if they are actually part of the URL, and aren't punctuation. I've done some research and it seems that no valid URLs intentionally end with any of the `.,?!:;'"` characters. So changing the regex seems like the best solution to me.

I've run the `link.vim` tests on this modified regex. I'm not sure how the `wiki.vim` tests work; it would be a good idea to test this on your part too.
