### PR TITLE
Allow complete customization of setting link target

### DIFF
--- a/autoload/wiki/link.vim
+++ b/autoload/wiki/link.vim
@@ -132,15 +132,17 @@ function! wiki#link#add(path, mode, ...) abort " {{{1
 
   let l:options = extend(l:defaults, a:0 > 0 ? a:1 : {})
 
-  if wiki#paths#is_abs(a:path)
+  let l:url = a:path
+  if has_key(l:creator, 'url_transform')
+    let l:transformed = l:creator.url_transform(a:path)
+    if !empty(l:transformed)
+      let l:url = l:transformed
+    endif
+  elseif wiki#paths#is_abs(a:path)
     let l:cwd = expand('%:p:h')
     let l:url = stridx(a:path, l:cwd) == 0
           \ ? wiki#paths#to_wiki_url(a:path, l:cwd)
           \ : '/' .. wiki#paths#to_wiki_url(a:path)
-  else
-    let l:url = has_key(l:creator, 'url_transform')
-          \ ? l:creator.url_transform(a:path)
-          \ : a:path
   endif
 
   let l:link_string = wiki#link#template(l:url, l:options.text)


### PR DESCRIPTION
The problem I would like to solve is to create the link using the relative path instead of absolute path from `WikiLinkAdd`. It's on a markdown file and using md format. The file in the buffer and the link to add are in the same wiki root.

When I use `WikiLinkAdd` and select a file, the link target is always an absolute path from the wiki root, despite I try to customize it in vimrc file. 

In this change, the customized function will always be called to transform the link target, if the customized function exists. Then it'll fall back to the existing logic of using the absolute path.